### PR TITLE
fix:デプロイエラー修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,5 +99,6 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.active_storage.service = :cloudinary
+  #config.active_storage.service = :cloudinary
+  config.active_storage.service = :local
 end


### PR DESCRIPTION
## 目的
Cloudinaryの認証エラーによるビルド失敗を解消し、初期デプロイを完了させる。

## 内容
- production.rb の storage service を :cloudinary から :local へ変更（暫定措置）
- パッケージマネージャの整理（不要なロックファイルの削除）

## 完了条件
- [ ] Render でのビルドおよびデプロイが SUCCESS になること
- [ ] Cloudinary の APIキーエラーがログから消えること