### PR TITLE
feat: ハーブ図鑑のUI整備・タグ分類・編集削除機能の追加

### DIFF
--- a/app/controllers/herbs_controller.rb
+++ b/app/controllers/herbs_controller.rb
@@ -46,8 +46,8 @@ class HerbsController < ApplicationController
 
   def set_tags
     @flavor_tags = FlavorTag.all
-    @functional_tags = FunctionalTag.all
-    @caution_tags = CautionTag.all
+    @grouped_functional_tags = FunctionalTag.grouped_by_category
+    @grouped_caution_tags = CautionTag.grouped_by_category
   end
 
   def herb_params

--- a/app/models/caution_tag.rb
+++ b/app/models/caution_tag.rb
@@ -1,2 +1,16 @@
 class CautionTag < ApplicationRecord
+  CATEGORIES = {
+    "ライフステージ" => ["妊娠中注意", "授乳中注意", "小児使用注意", "高齢者注意"],
+    "既往症・体質"   => ["高血圧注意", "低血圧注意", "糖尿病注意", "アレルギー注意"],
+    "臓器機能"       => ["肝機能低下時注意", "腎機能低下時注意"],
+    "作用特性"       => ["ホルモン感受性注意", "鎮静作用あり", "光感作注意", "利尿作用あり"],
+    "相互作用"       => ["薬剤服用中注意", "抗凝固薬注意"]
+  }.freeze
+
+  def self.grouped_by_category
+    all_tags = all.index_by(&:name)
+    CATEGORIES.transform_values do |names|
+      names.filter_map { |name| all_tags[name] }
+    end
+  end
 end

--- a/app/models/functional_tag.rb
+++ b/app/models/functional_tag.rb
@@ -1,2 +1,17 @@
 class FunctionalTag < ApplicationRecord
+  CATEGORIES = {
+    "心・自律神経" => ["リラックス（鎮静）", "睡眠サポート", "ストレス緩和", "集中力向上", "気分リフレッシュ"],
+    "消化・代謝"   => ["消化促進", "胃腸ケア", "食欲調整", "デトックス", "利尿作用", "整腸作用", "血糖値サポート"],
+    "症状ケア"     => ["抗炎症", "抗酸化", "抗菌", "抗アレルギー", "鎮痙作用", "喉ケア"],
+    "免疫・循環"   => ["免疫サポート", "血行促進", "発汗作用", "冷え対策", "ホルモンバランス"],
+    "美容・栄養"   => ["美肌ケア", "ミネラル補給", "エイジングケア"],
+    "活力・疲労"   => ["疲労回復", "眼精疲労サポート", "滋養補給"]
+  }.freeze
+
+  def self.grouped_by_category
+    all_tags = all.index_by(&:name)
+    CATEGORIES.transform_values do |names|
+      names.filter_map { |name| all_tags[name] }
+    end
+  end
 end

--- a/app/views/herbs/edit.html.erb
+++ b/app/views/herbs/edit.html.erb
@@ -1,4 +1,98 @@
-<div>
-  <h1 class="font-bold text-4xl">Herbs#edit</h1>
-  <p>Find me in app/views/herbs/edit.html.erb</p>
+<div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4 space-y-3 w-full">
+
+  <div class="max-w-lm bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5">
+    <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+      <h2 class="flex justify-center text-2xl text-herb-green-700 font-medium tracking-wide">
+        ハーブを編集する
+      </h2>
+    </div>
+  <br>
+  <%= form_with model: @herb do |form| %>
+
+    <% if @herb.errors.any? %>
+      <div class="bg-red-100 text-red-700 p-3 rounded mb-4">
+        <% @herb.errors.full_messages.each do |msg| %>
+          <p><%= msg %></p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%# ハーブ名 %>
+    <div class="mb-4">
+      <%= form.label :name, "ハーブ名", class: "form-label" %>
+      <%= form.text_field :name, placeholder: "例：カモミール" %>
+    </div>
+
+    <%# 説明 %>
+    <div class="mb-4">
+      <%= form.label :description, "説明", class: "form-label" %>
+      <%= form.text_area :description, rows: 3 %>
+    </div>
+
+    <%# 風味タグ（複数選択） %>
+    <div class="mb-4">
+      <p class="form-label">風味タグ</p>
+      <div class="flex flex-wrap gap-2">
+        <% @flavor_tags.each do |tag| %>
+          <label class="cursor-pointer">
+            <%= check_box_tag "herb[flavor_tag_ids][]", tag.id,
+                @herb.flavor_tag_ids.include?(tag.id),
+                id: "flavor_tag_#{tag.id}" %>
+            <span class="tag-herb ml-1"><%= tag.name %></span>
+          </label>
+        <% end %>
+      </div>
+    </div>
+
+    <%# 効能タグ（カテゴリ別） %>
+    <div class="mb-4">
+      <p class="form-label">効能タグ</p>
+      <% @grouped_functional_tags.each do |category, tags| %>
+        <% next if tags.empty? %>
+        <p class="text-xs text-herb-green-700/50 mt-3 mb-1 font-medium"><%= category %></p>
+        <div class="flex flex-wrap gap-2">
+          <% tags.each do |tag| %>
+            <label class="cursor-pointer">
+              <%= check_box_tag "herb[functional_tag_ids][]", tag.id,
+                  @herb.functional_tag_ids.include?(tag.id),
+                  id: "functional_tag_#{tag.id}" %>
+              <span class="tag-benefit ml-1"><%= tag.name %></span>
+            </label>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <%# 禁忌タグ（カテゴリ別） %>
+    <div class="mb-4">
+      <p class="form-label">禁忌タグ</p>
+      <% @grouped_caution_tags.each do |category, tags| %>
+        <% next if tags.empty? %>
+        <p class="text-xs text-red-400 mt-3 mb-1 font-medium"><%= category %></p>
+        <div class="flex flex-wrap gap-2">
+          <% tags.each do |tag| %>
+            <label class="cursor-pointer">
+              <%= check_box_tag "herb[caution_tag_ids][]", tag.id,
+                  @herb.caution_tag_ids.include?(tag.id),
+                  id: "caution_tag_#{tag.id}" %>
+              <span class="bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full ml-1">
+                ⚠ <%= tag.name %>
+              </span>
+            </label>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <%# 禁忌・注意事項 %>
+    <div class="mb-4">
+      <%= form.label :caution, "禁忌・注意事項", class: "form-label" %>
+      <%= form.text_area :caution, rows: 2 %>
+    </div>
+
+    <%= form.submit "更新する", class: "btn-primary-lg w-full justify-center" %>
+
+  <% end %>
+  </div>
+
 </div>

--- a/app/views/herbs/index.html.erb
+++ b/app/views/herbs/index.html.erb
@@ -20,15 +20,15 @@
           <%= link_to herb_path(herb), class: "herb-card hover:opacity-80 transition" do %>
 
             <%# 画像（小さく・左寄り） %>
-            <div class="w-12 h-12 rounded-lg overflow-hidden bg-herb-green-50 flex-shrink-0">
-              <% if herb.image.attached? %>
-                <%= image_tag herb.image, class: "w-full h-full object-cover" %>
-              <% else %>
-                <div class="w-full h-full flex items-center justify-center text-herb-green-700/30 text-xs">
-                  NO IMG
-                </div>
-              <% end %>
-            </div>
+            <%# <div class="w-12 h-12 rounded-lg overflow-hidden bg-herb-green-50 flex-shrink-0"> %>
+              <%# <% if herb.image.attached? %>
+                <%# <%= image_tag herb.image, class: "w-full h-full object-cover" %>
+              <%# <% else %>
+                <%# <div class="w-full h-full flex items-center justify-center text-herb-green-700/30 text-xs"> %>
+                  <%# NO IMG %>
+                <%# </div> %>
+              <%# <% end %>
+            <%# </div> %>
 
             <%# テキスト情報（右側） %>
             <div class="flex-1 min-w-0">

--- a/app/views/herbs/index.html.erb
+++ b/app/views/herbs/index.html.erb
@@ -38,7 +38,7 @@
               <% if herb.flavor_tags.any? %>
                 <div class="flex flex-wrap gap-1 mt-1">
                   <% herb.flavor_tags.each do |tag| %>
-                    <span class="w-full h-full tag-herb"><%= tag.name %></span>
+                    <span class="flex flex-wrap gap-1 tag-herb"><%= tag.name %></span>
                   <% end %>
                 </div>
               <% end %>
@@ -47,7 +47,7 @@
               <% if herb.functional_tags.any? %>
                 <div class="flex flex-wrap gap-1 mt-1">
                   <% herb.functional_tags.each do |tag| %>
-                    <span class="w-full h-full tag-benefit"><%= tag.name %></span>
+                    <span class="flex flex-wrap gap-1 tag-benefit"><%= tag.name %></span>
                   <% end %>
                 </div>
               <% end %>
@@ -56,7 +56,7 @@
               <% if herb.caution_tags.any? %>
                 <div class="flex flex-wrap gap-1">
                   <% herb.caution_tags.each do |tag| %>
-                    <span class="w-full h-full bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
+                    <span class="flex flex-wrap gap-1 mt-1 bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
                       ⚠ <%= tag.name %>
                     </span>
                   <% end %>

--- a/app/views/herbs/new.html.erb
+++ b/app/views/herbs/new.html.erb
@@ -6,7 +6,7 @@
         ハーブを登録する
       </h2>
     </div>
-
+  <br>
   <%= form_with model: @herb do |form| %>
 
     <% if @herb.errors.any? %>

--- a/app/views/herbs/new.html.erb
+++ b/app/views/herbs/new.html.erb
@@ -90,14 +90,14 @@
     </div>
 
     <%# 画像 %>
-    <div class="mb-6">
-      <%= form.label :image, "ハーブ画像", class: "form-label" %>
-      <%= form.file_field :image,
-          accept: Herb::ACCEPTED_CONTENT_TYPES.join(",") %>
-      <p class="text-xs text-herb-green-700/60 mt-1">
-        JPEG・PNG・GIF・WebP形式、5MB以下
-      </p>
-    </div>
+    <%# <div class="mb-6"> %>
+      <%# <%= form.label :image, "ハーブ画像", class: "inline-block border rounded-full px-6 py-2" %>
+      <%# <%= form.file_field :image, %>
+          <%# accept: Herb::ACCEPTED_CONTENT_TYPES.join(",") %>
+      <%# <p class="text-xs text-herb-green-700/60 mt-1"> %>
+        <%# JPEG・PNG・GIF・WebP形式、5MB以下 %>
+      <%# </p> %>
+    <%# </div> %>
 
     <%= form.submit "登録する", class: "btn-primary-lg w-full justify-center" %>
 

--- a/app/views/herbs/new.html.erb
+++ b/app/views/herbs/new.html.erb
@@ -1,7 +1,11 @@
 <div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4 space-y-3 w-full">
 
-<div class="max-w-md mx-auto mt-10 p-6 pb-24">
-  <h1 class="text-2xl text-herb-green-700 mb-6">ハーブを登録する</h1>
+  <div class="max-w-lm bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5">
+    <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+      <h2 class="flex justify-center text-2xl md:text-2xl text-herb-green-700 font-medium tracking-wide">
+        ハーブを登録する
+      </h2>
+    </div>
 
   <%= form_with model: @herb do |form| %>
 
@@ -40,36 +44,44 @@
       </div>
     </div>
 
-    <%# 効能タグ（複数選択） %>
+    <%# 効能タグ（カテゴリ別） %>
     <div class="mb-4">
       <p class="form-label">効能タグ</p>
-      <div class="flex flex-wrap gap-2">
-        <% @functional_tags.each do |tag| %>
-          <label class="cursor-pointer">
-            <%= check_box_tag "herb[functional_tag_ids][]", tag.id,
-                @herb.functional_tag_ids.include?(tag.id),
-                id: "functional_tag_#{tag.id}" %>
-            <span class="tag-benefit ml-1"><%= tag.name %></span>
-          </label>
-        <% end %>
-      </div>
+      <% @grouped_functional_tags.each do |category, tags| %>
+        <% next if tags.empty? %>
+        <p class="text-xs text-herb-green-700/50 mt-3 mb-1 font-medium"><%= category %></p>
+        <div class="flex flex-wrap gap-2">
+          <% tags.each do |tag| %>
+            <label class="cursor-pointer">
+              <%= check_box_tag "herb[functional_tag_ids][]", tag.id,
+                  @herb.functional_tag_ids.include?(tag.id),
+                  id: "functional_tag_#{tag.id}" %>
+              <span class="tag-benefit ml-1"><%= tag.name %></span>
+            </label>
+          <% end %>
+        </div>
+      <% end %>
     </div>
 
-    <%# 禁忌タグ%>
+    <%# 禁忌タグ（カテゴリ別） %>
     <div class="mb-4">
       <p class="form-label">禁忌タグ</p>
-      <div class="flex flex-wrap gap-2">
-        <% @caution_tags.each do |tag| %>
-          <label class="cursor-pointer">
-            <%= check_box_tag "herb[caution_tag_ids][]", tag.id,
-                @herb.caution_tag_ids.include?(tag.id),
-                id: "caution_tag_#{tag.id}" %>
-            <span class="bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full ml-1">
-              ⚠ <%= tag.name %>
-            </span>
-          </label>
-        <% end %>
-      </div>
+      <% @grouped_caution_tags.each do |category, tags| %>
+        <% next if tags.empty? %>
+        <p class="text-xs text-red-400 mt-3 mb-1 font-medium"><%= category %></p>
+        <div class="flex flex-wrap gap-2">
+          <% tags.each do |tag| %>
+            <label class="cursor-pointer">
+              <%= check_box_tag "herb[caution_tag_ids][]", tag.id,
+                  @herb.caution_tag_ids.include?(tag.id),
+                  id: "caution_tag_#{tag.id}" %>
+              <span class="bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full ml-1">
+                ⚠ <%= tag.name %>
+              </span>
+            </label>
+          <% end %>
+        </div>
+      <% end %>
 
     <%# 禁忌 %>
     <div class="mb-4">

--- a/app/views/herbs/show.html.erb
+++ b/app/views/herbs/show.html.erb
@@ -11,15 +11,16 @@
 
   <div class="flex gap-4 mb-6 justify-center">
     <%# 画像 %>
-    <div class="w-full rounded-2xl overflow-hidden aspect-video">
-      <% if @herb.image.attached? %>
-        <%= image_tag @herb.image, class: "w-full h-full object-cover" %>
-      <% else %>
-        <div class="w-full h-full flex items-center justify-center text-herb-green-700/30">
-          画像なし
-        </div>
-      <% end %>
-    </div>
+    <%# <div class="w-full rounded-2xl overflow-hidden aspect-video"> %>
+      <%# <% if @herb.image.attached? %>
+        <%# <%= image_tag @herb.image, class: "w-full h-full object-cover" %>
+      <%# <% else %>
+        <%# <div class="w-full h-full flex items-center justify-center text-herb-green-700/30"> %>
+          <%# 画像なし %>
+        <%# </div> %>
+      <%# <% end %>
+    <%# </div> %>
+
     <div class="flex flex-col gap-1 w-full">
       <%# 風味タグ %>
       <% if @herb.flavor_tags.any? %>

--- a/app/views/herbs/show.html.erb
+++ b/app/views/herbs/show.html.erb
@@ -1,5 +1,5 @@
-<div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4 space-y-3 w-full">
-<div class="max-w-sm bg-white rounded-2xl shadow-sm border border-herb-green-100 p-8 md:p-10">
+<div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-3 space-y-3 w-full">
+<div class="max-w-lm bg-white rounded-2xl shadow-sm border border-herb-green-100 p-8 md:p-10">
 
   <%# 名称・別名 %>
   <h1 class="text-2xl text-herb-green-700 font-medium"><%= @herb.name %></h1>
@@ -20,10 +20,10 @@
         </div>
       <% end %>
     </div>
-    <div class="flex flex-col gap-4 w-full">
+    <div class="flex flex-col gap-1 w-full">
       <%# 風味タグ %>
       <% if @herb.flavor_tags.any? %>
-        <p class="text-xs text-herb-green-700/50 mb-2">風味</p>
+        <p class="text-xs text-herb-green-700/50">風味</p>
         <div class="flex flex-wrap gap-1">
           <% @herb.flavor_tags.each do |tag| %>
             <span class="flex flex-wrap gap-1 tag-herb"><%= tag.name %></span>
@@ -33,7 +33,7 @@
 
       <%# 効能タグ %>
       <% if @herb.functional_tags.any? %>
-        <p class="text-xs text-herb-green-700/50 mb-2">効能</p>
+        <p class="text-xs text-herb-green-700/50">効能</p>
         <div class="flex flex-wrap gap-1">
           <% @herb.functional_tags.each do |tag| %>
             <span class="flex flex-wrap gap-1 tag-benefit"><%= tag.name %></span>
@@ -43,7 +43,7 @@
 
       <%# 禁忌タグ %>
       <% if @herb.caution_tags.any? %>
-        <p class="text-xs text-herb-green-700/50 mb-2">禁忌</p>
+        <p class="text-xs text-herb-green-700/50">禁忌</p>
         <div class="flex flex-wrap gap-1">
           <% @herb.caution_tags.each do |tag| %>
             <span class="flex flex-wrap gap-1 bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
@@ -57,15 +57,15 @@
 
   <%# 説明 %>
   <% if @herb.description.present? %>
-    <div class="bg-herb-green-50/50 rounded-2xl p-4 border border-herb-green-100">
+    <div class="bg-herb-green-50/50 rounded-2xl p-2 border border-herb-green-100">
       <p class="text-xs text-herb-green-700/50 mb-2">説明</p>
-      <p class="text-sm text-herb-green-700/80 leading-relaxed mb-4"><%= @herb.description %></p>
+      <p class="text-sm text-herb-green-700/80 leading-relaxed"><%= @herb.description %></p>
     </div>
   <% end %>
   <br>
   <%# 禁忌・注意事項 %>
   <% if @herb.caution.present? %>
-    <div class="bg-red-50 rounded-2xl p-4 border border-red-100">
+    <div class="bg-red-50 rounded-2xl p-2 border border-red-100">
       <p class="text-xs text-red-500 mb-2">⚠ 禁忌・注意事項</p>
       <p class="text-sm text-red-700 leading-relaxed"><%= @herb.caution %></p>
     </div>

--- a/app/views/herbs/show.html.erb
+++ b/app/views/herbs/show.html.erb
@@ -23,83 +23,53 @@
     <div class="flex flex-col gap-4 w-full">
       <%# 風味タグ %>
       <% if @herb.flavor_tags.any? %>
-        <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-          <p class="text-xs text-herb-green-700/50 mb-2">風味</p>
-          <div class="flex flex-wrap gap-1">
-            <% @herb.flavor_tags.each do |tag| %>
-              <span class="w-full h-full tag-herb"><%= tag.name %></span>
-            <% end %>
-          </div>
+        <p class="text-xs text-herb-green-700/50 mb-2">風味</p>
+        <div class="flex flex-wrap gap-1">
+          <% @herb.flavor_tags.each do |tag| %>
+            <span class="flex flex-wrap gap-1 tag-herb"><%= tag.name %></span>
+          <% end %>
         </div>
       <% end %>
 
       <%# 効能タグ %>
       <% if @herb.functional_tags.any? %>
-        <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-          <p class="text-xs text-herb-green-700/50 mb-2">効能</p>
-          <div class="flex flex-wrap gap-1">
-            <% @herb.functional_tags.each do |tag| %>
-              <span class="w-full h-full tag-benefit"><%= tag.name %></span>
-            <% end %>
-          </div>
+        <p class="text-xs text-herb-green-700/50 mb-2">効能</p>
+        <div class="flex flex-wrap gap-1">
+          <% @herb.functional_tags.each do |tag| %>
+            <span class="flex flex-wrap gap-1 tag-benefit"><%= tag.name %></span>
+          <% end %>
         </div>
       <% end %>
 
       <%# 禁忌タグ %>
       <% if @herb.caution_tags.any? %>
-        <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-          <p class="text-xs text-herb-green-700/50 mb-2">禁忌</p>
-          <div class="flex flex-wrap gap-1">
-            <% @herb.caution_tags.each do |tag| %>
-              <span class="w-full h-full bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
-                ⚠ <%= tag.name %>
-              </span>
-            <% end %>
-          </div>
+        <p class="text-xs text-herb-green-700/50 mb-2">禁忌</p>
+        <div class="flex flex-wrap gap-1">
+          <% @herb.caution_tags.each do |tag| %>
+            <span class="flex flex-wrap gap-1 bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
+              ⚠ <%= tag.name %>
+            </span>
+          <% end %>
         </div>
       <% end %>
     </div>
   </div>
 
-    <%# 有効成分 %>
-    <% if @herb.active_ingredients.present? %>
-      <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-        <p class="text-xs text-herb-green-700/50 mb-2">有効成分</p>
-        <p class="text-sm text-herb-green-700"><%= @herb.active_ingredients %></p>
-      </div>
-    <% end %>
-
-    <%# 風味の特徴 %>
-    <% if @herb.flavor_description.present? %>
-      <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-        <p class="text-xs text-herb-green-700/50 mb-2">風味の特徴</p>
-        <p class="text-sm text-herb-green-700 leading-relaxed"><%= @herb.flavor_description %></p>
-      </div>
-    <% end %>
-
-    <%# 効能の説明 %>
-    <% if @herb.effect_description.present? %>
-      <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-        <p class="text-xs text-herb-green-700/50 mb-2">効能の説明</p>
-        <p class="text-sm text-herb-green-700 leading-relaxed"><%= @herb.effect_description %></p>
-      </div>
-    <% end %>
-
-    <%# 禁忌の説明 %>
-    <% if @herb.caution_description.present? %>
-      <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-        <p class="text-xs text-herb-green-700/50 mb-2">禁忌の説明</p>
-        <p class="text-sm text-herb-green-700 leading-relaxed"><%= @herb.caution_description %></p>
-      </div>
-    <% end %>
-
-    <%# 歴史 %>
-    <% if @herb.history.present? %>
-      <div class="bg-white rounded-2xl p-4 border border-herb-green-100">
-        <p class="text-xs text-herb-green-700/50 mb-2">歴史</p>
-        <p class="text-sm text-herb-green-700 leading-relaxed"><%= @herb.history %></p>
-      </div>
-    <% end %>
+  <%# 説明 %>
+  <% if @herb.description.present? %>
+    <div class="bg-herb-green-50/50 rounded-2xl p-4 border border-herb-green-100">
+      <p class="text-xs text-herb-green-700/50 mb-2">説明</p>
+      <p class="text-sm text-herb-green-700/80 leading-relaxed mb-4"><%= @herb.description %></p>
+    </div>
+  <% end %>
+  <br>
+  <%# 禁忌・注意事項 %>
+  <% if @herb.caution.present? %>
+    <div class="bg-red-50 rounded-2xl p-4 border border-red-100">
+      <p class="text-xs text-red-500 mb-2">⚠ 禁忌・注意事項</p>
+      <p class="text-sm text-red-700 leading-relaxed"><%= @herb.caution %></p>
+    </div>
+  <% end %>
 
   <br>
   <%= link_to "一覧に戻る", herbs_path,

--- a/app/views/herbs/show.html.erb
+++ b/app/views/herbs/show.html.erb
@@ -73,8 +73,15 @@
   <% end %>
 
   <br>
-  <%= link_to "一覧に戻る", herbs_path,
-    class:"inline-block border rounded-full px-6 py-2" %>
+  <div class="flex gap-3 items-center">
+    <%= link_to "一覧に戻る", herbs_path,
+        class: "inline-block border border-herb-green-600 text-herb-green-600 rounded-full px-5 py-2 text-sm hover:bg-herb-green-50 transition" %>
+    <%= link_to "編集", edit_herb_path(@herb),
+        class: "inline-block bg-herb-green-600 text-white rounded-full px-5 py-2 text-sm hover:bg-herb-green-700 transition" %>
+    <%= link_to "削除", herb_path(@herb),
+        data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
+        class: "inline-block bg-red-100 text-red-600 rounded-full px-5 py-2 text-sm hover:bg-red-200 transition" %>
+  </div>
 
 </div>
 </div>


### PR DESCRIPTION
## 概要

ハーブ図鑑（herbs）の一覧・詳細・登録・編集画面のUI整備と、
効能タグ・禁忌タグのカテゴリ分類表示、編集・削除機能を実装した。
                                                                                        
## 変更内容

### タグのカテゴリ分類（Issue 15 関連）                                               
- `FunctionalTag` / `CautionTag` モデルに `CATEGORIES` 定数と
`grouped_by_category` クラスメソッドを追加                                          
- `HerbsController#set_tags` でカテゴリ別グループに変更                               
- `herbs/new.html.erb` の効能・禁忌タグをカテゴリ見出し付きで表示                     
    例）心・自律神経 / 消化・代謝 / ライフステージ など                                 
                                                                                        
### ハーブ詳細画面の情報追加（herbs/show）                                            
- 登録フォームに存在するにもかかわらず未表示だった                                    
`description`（説明）と `caution`（禁忌・注意事項）を表示欄に追加                   
- 編集・削除ボタンを追加（削除は確認ダイアログ付き）                                  
                                                                                        
### 編集フォームの実装（herbs/edit）                                                  
- プレースホルダーのみだった `edit.html.erb` を `new` と同構造で実装                  
- 既存値がプリセットされた状態でフォームを表示                                        
                                                                                        
### UI調整                                                                            
- 一覧・詳細・登録画面の横幅・余白・タグ間隔を統一                                    
- 画像保存フィールドをコメントアウト（本リリース Issue 37 で管理者画面に実装予定）    
                                                                                        
## 非対応事項（本リリースへ持ち越し）                                                 
- 画像アップロード（Issue 37: 管理者用ハーブマスタ編集機能）                          
- 編集・削除の権限制御（Issue 36: 管理者権限の導入）  