### PR TITLE
新規登録時のエラーメッセージ改善

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
     errors:
       messages:
         blank: "を入力してください"
-        taken: "はすでに使用されています"
+        taken: "は現在使用できません"
         confirmation: "と%{attribute}が一致しません"
     models:
       user: "ユーザー"


### PR DESCRIPTION
### 概要
新規ユーザー登録において、既に使用されているメールアドレスが入力された際のエラーメッセージを変更しました。

### 変更内容
config/locales/en.ymlの更新
「メールアドレスはすでに使用されています」→「メールアドレスは現在使用できません」に変更