### PR TITLE
style: ハーブ図鑑の新規作成ボタンを一時的にコメントアウト

### DIFF
--- a/app/views/herbs/index.html.erb
+++ b/app/views/herbs/index.html.erb
@@ -70,7 +70,8 @@
     <% end %>       <%# if の end %>
 
     <div class="flex justify-center space-y-3 mt-3 pt-2">
-      <%= link_to "＋ 新規登録", new_herb_path, class: "btn-primary-lg" %>
+      <%# 管理者権限導入後に if current_user.admin? で制御予定 %>
+      <%#= link_to "＋ 新規登録", new_herb_path, class: "btn-primary-lg" %>
     </div>
   </div>
 


### PR DESCRIPTION
### 変更概要

ハーブ図鑑一覧（`/herbs`）の「＋ 新規登録」ボタンを非表示にしました。
将来的な管理者権限（`current_user.admin?`）導入に向けた第1段階の対応です。

### 変更ファイル

- `app/views/herbs/index.html.erb` — 新規登録ボタンをコメントアウト

### 変更しなかった箇所

- `herbs/show` の編集・削除ボタンは既に作成者のみ表示（`@herb.user_id == current_user.id`）のため変更なし
- Controller 側の制限（URL直打き対策）は Issue 41 の admin 権限導入時に対応予定

### 確認事項

- [x] ログイン状態で `/herbs` に「＋ 新規登録」ボタンが表示されないこと

### 関連issue
Closes #53 