### PR TITLE
fix: i18nロケールキーの不整合によるフラッシュ・エラーメッセージの翻訳エラーを修正

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,24 +3,26 @@ project_name: "herb_recipe_lab"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  ansible             bash                clojure             cpp
-#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
-#   elixir              elm                 erlang              fortran             fsharp
-#   go                  groovy              haskell             haxe                hlsl
-#   java                json                julia               kotlin              lean4
-#   lua                 luau                markdown            matlab              msl
-#   nix                 ocaml               pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         python_ty
-#   r                   rego                ruby                ruby_solargraph     rust
-#   scala               solidity            swift               systemverilog       terraform
-#   toml                typescript          typescript_vts      vue                 yaml
-#   zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -125,3 +127,14 @@ ignored_memory_patterns: []
 # The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/app/views/drinking_logs/new.html.erb
+++ b/app/views/drinking_logs/new.html.erb
@@ -18,6 +18,17 @@
     </div>
       <%= render 'recipes/recipe_summary', recipe: @recipe %>
 
+    <% if @drinking_log.errors.any? %>
+      <div class="bg-red-50 border border-red-200 rounded-xl p-4 mb-6">
+        <p class="text-red-600 text-sm font-medium mb-1">入力内容を確認してください</p>
+        <ul class="text-red-500 text-sm space-y-1">
+          <% @drinking_log.errors.full_messages.each do |msg| %>
+            <li>・<%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <%= form_with model: [@recipe, @drinking_log], class: "space-y-6" do |f| %>
 
       <%# 総合評価 %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,6 +1,6 @@
 # Additional translations at https://github.com/heartcombo/devise/wiki/I18n
 
-en:
+ja:
   devise:
     confirmations:
       confirmed: "メールアドレスの確認が完了しました。"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,36 +29,3 @@
 
 en:
   hello: "Hello world"
-  errors:
-    format: "%{attribute}%{message}"
-  activerecord:
-    errors:
-      messages:
-        blank: "を入力してください"
-        taken: "は現在使用できません"
-        confirmation: "と%{attribute}が一致しません"
-    models:
-      user: "ユーザー"
-    attributes:
-      user:
-        email: "メールアドレス"
-        password: "パスワード"
-        password_confirmation: "パスワード（確認用）"
-        name: "ユーザー名"
-      recipe:
-        title: "レシピ名"
-        brewed_at: "作成日"
-      recipe/recipe_herbs:
-        quantity: "配合量"
-        herb: "ハーブ"
-        herb_id: "ハーブ"
-        custom_herb_name: "ハーブ名"
-      recipe_herb:
-        quantity: "配合量"
-        herb: "ハーブ"
-        herb_id: "ハーブ"
-        custom_herb_name: "ハーブ名"
-      herb:
-        name: "ハーブ名"
-      drinking_log:
-        rating: "総合評価"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,3 +9,46 @@ ja:
       default: "%Y/%m/%d"
       short: "%m/%d"
       long: "%Y年%m月%d日"
+  errors:
+    format: "%{attribute}%{message}"
+  activerecord:
+    errors:
+      messages:
+        blank: "を入力してください"
+        taken: "は現在使用できません"
+        confirmation: "と%{attribute}が一致しません"
+    models:
+      user: "ユーザー"
+    attributes:
+      user:
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認用）"
+        name: "ユーザー名"
+      recipe:
+        title: "レシピ名"
+        brewed_at: "作成日"
+      recipe/recipe_herbs:
+        quantity: "配合量"
+        herb: "ハーブ"
+        herb_id: "ハーブ"
+        custom_herb_name: "ハーブ名"
+      recipe_herb:
+        quantity: "配合量"
+        herb: "ハーブ"
+        herb_id: "ハーブ"
+        custom_herb_name: "ハーブ名"
+      herb:
+        name: "ハーブ名"
+        image: "画像"
+      drinking_log:
+        rating: "総合評価"
+        sweetness: "甘み"
+        acidity: "酸味"
+        bitterness: "苦み"
+        astringency: "渋み"
+        fruity: "フルーティさ"
+        spicy: "スパイシーさ"
+        freshness: "さわやかさ"
+        flowery: "花のような香り"
+        impression: "感想"


### PR DESCRIPTION
### 概要

画面遷移時に発生していたフラッシュメッセージ・エラーメッセージの翻訳エラーを修正します。

### 原因

`config/application.rb` で `default_locale = :ja` が設定されているにもかかわらず、
翻訳ファイルがすべて `en:` キー以下に定義されていました。
Rails が `ja.activerecord.errors.messages.*` を探しても見つからず、
`translation missing: ja.*` エラーが発生していました。


### 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `config/locales/ja.yml` | `en.yml` の activerecord 翻訳を移行。DrinkingLog フレーバー属性 8 項目・herb.image も追加 |
| `config/locales/devise.en.yml` | ルートキーを `en:` → `ja:` に変更 |
| `config/locales/en.yml` | activerecord セクションを削除（`ja.yml` に移行済み） |
| `app/views/drinking_logs/new.html.erb` | バリデーションエラー表示ブロックを追加 |

### 確認項目

- [ ] レシピ作成でタイトル空欄送信 → 「レシピ名を入力してください」が表示される
- [ ] ハーブ登録で名前空欄送信 → 「ハーブ名を入力してください」が表示される
- [ ] 感想入力で評価未選択送信 → エラーが表示される
- [ ] ユーザー登録でエラー発生 → Devise のエラーメッセージが正常に表示される
- [ ] ログイン失敗 → flash alert が正常に表示される