### PR TITLE
Feature/ ページネーション導入・home画面タブ分割・FABボタン実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ end
 
 gem "tailwindcss-rails", "~> 4.4"
 gem 'devise'
-
+gem 'kaminari'
 gem "cloudinary"
 gem 'activestorage-cloudinary-service'
 gem 'dotenv-rails', groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.19.3)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -372,6 +384,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  kaminari
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -135,4 +135,26 @@
   .nav-icon {
     @apply h-7 w-7 mb-1; /* アイコンを少し小さく、文字との間隔を調整 */
   }
+
+  /* kaminari pagination */
+  .pagination .btn-active {
+    background-color: theme('colors.herb-green-600') !important;
+    border-color: theme('colors.herb-green-600') !important;
+    color: theme('colors.herb-white') !important;
+  }
+
+  .pagination .btn-inactive {
+    background-color: theme('colors.herb-white') !important;
+    border-color: theme('colors.herb-green-600') !important;
+    color: #4b734b !important;
+  }
+
+  .pagination .btn-inactive:hover {
+    background-color: theme('colors.herb-green-100') !important;
+  }
 }
+
+@layer utilities {
+  /* ここにユーティリティクラスを追加できます */
+}
+

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -119,12 +119,12 @@
   }
   /* アクティブなタブ */
   .tab-item-active {
-    @apply flex-1 py-3 bg-herb-green-600 text-white font-medium text-center;
+    @apply flex-1 py-1 bg-herb-green-600 text-white font-medium text-center;
   }
 
   /* 非アクティブなタブ */
   .tab-item-inactive {
-    @apply flex-1 py-3 text-herb-green-600/60 font-medium italic text-center hover:bg-herb-green-100/30 transition;
+    @apply flex-1 py-1 text-herb-green-600/80 font-medium text-center hover:bg-herb-green-100/30 transition;
   }
 
   /* ナビゲーションボタン */
@@ -156,5 +156,56 @@
 
 @layer utilities {
   /* ここにユーティリティクラスを追加できます */
+  /* FAB ベース（スマホ: 丸ボタン） */
+  .btn-fab {
+    @apply fixed bottom-20 right-5 z-40
+          h-14 rounded-full
+          bg-herb-green-600 text-white
+          flex items-center justify-center
+          shadow-xl
+          hover:bg-herb-green-700/80 active:scale-95;
+    width: 3.5rem;
+    padding: 0;
+    gap: 0;
+    transition: width 0.3s ease, padding 0.3s ease, gap 0.3s ease;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  /* FABのテキスト（スマホ: 非表示） */
+  .btn-fab .fab-text {
+    max-width: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: max-width 0.3s ease, opacity 0.2s ease;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  /* スマホ: タップで展開 */
+  .btn-fab.fab-expanded {
+    width: auto;
+    padding: 0 1.25rem;
+    gap: 0.5rem;
+  }
+
+  .btn-fab.fab-expanded .fab-text {
+    max-width: 12rem;
+    opacity: 1;
+  }
+
+  /* PC(md以上): 常に楕円で表示 */
+  @media (min-width: 768px) {
+    .btn-fab {
+      width: auto;
+      padding: 0 1.25rem;
+      gap: 0.5rem;
+    }
+
+    .btn-fab .fab-text {
+      max-width: 12rem;
+      opacity: 1;
+    }
+  }
 }
 

--- a/app/controllers/herbs_controller.rb
+++ b/app/controllers/herbs_controller.rb
@@ -5,7 +5,9 @@ class HerbsController < ApplicationController
   before_action :authorize_herb!, only: [:edit, :update, :destroy]
 
   def index
-    @herbs = Herb.order(:name).includes(:flavor_tags, :functional_tags, :caution_tags)
+    @herbs = Herb.order(:name)
+                  .includes(:flavor_tags, :functional_tags, :caution_tags)
+                  .page(params[:page]).per(15)
   end
 
   def show

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -7,6 +7,7 @@ class RecipesController < ApplicationController
       .includes(:user, :drinking_log, recipe_herbs: :herb)
       .public_recipes  # ← where(is_public: true) からスコープに変更
       .recent          # ← order(created_at: :desc) からスコープに変更
+      .page(params[:page]).per(10)  # ← ページネーション追加
   end
 
   def new

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,10 +10,17 @@ class StaticPagesController < ApplicationController
   end
 
   def home
-    # 公開レシピ OR 自分のレシピ（非公開含む）を取得
-    @recipes = Recipe
+    # みんなのブレンド（公開レシピ全件。自分のも含む）
+    @public_recipes = Recipe
       .includes(:user, :drinking_log, recipe_herbs: :herb)
-      .where("is_public = ? OR user_id = ?", true, current_user.id)
+      .public_recipes
       .recent
+      .page(params[:page]).per(10)
+
+    # 自分のブレンド（非公開含む）
+    @my_recipes = current_user.recipes
+      .includes(:drinking_log, recipe_herbs: :herb)
+      .recent
+      .page(params[:my_page]).per(10)
   end
 end

--- a/app/controllers/tea_reviews_controller.rb
+++ b/app/controllers/tea_reviews_controller.rb
@@ -3,7 +3,9 @@ class TeaReviewsController < ApplicationController
   before_action :set_tea_review, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tea_reviews = current_user.tea_reviews.includes(:herbs).order(created_at: :desc)
+    @tea_reviews = current_user.tea_reviews
+      .includes(:herbs).order(created_at: :desc)
+      .page(params[:page]).per(10)
   end
 
   def new

--- a/app/javascript/controllers/fab_controller.js
+++ b/app/javascript/controllers/fab_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    this.expanded = false;
+    this.collapseHandler = (e) => {
+      if (!this.element.contains(e.target)) this.collapse();
+    };
+    document.addEventListener("click", this.collapseHandler);
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.collapseHandler);
+    clearTimeout(this.timer);
+  }
+
+  toggle(event) {
+    // PC幅(768px以上)では即遷移
+    if (window.innerWidth >= 768) return;
+
+    event.preventDefault();
+
+    if (!this.expanded) {
+      this.expanded = true;
+      this.element.classList.add("fab-expanded");
+      clearTimeout(this.timer);
+      this.timer = setTimeout(() => this.collapse(), 3000);
+    } else {
+      window.location.href = this.element.href;
+    }
+  }
+
+  collapse() {
+    this.expanded = false;
+    this.element.classList.remove("fab-expanded");
+    clearTimeout(this.timer);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,11 +4,14 @@
 
 import { application } from "./application"
 
+import AddFieldController from "./add_field_controller"
+application.register("add-field", AddFieldController)
+
+import FabController from "./fab_controller"
+application.register("fab", FabController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
 import ToggleRadioController from "./toggle_radio_controller"
 application.register("toggle-radio", ToggleRadioController)
-
-import AddFieldController from "./add_field_controller"
-application.register("add-field", AddFieldController)

--- a/app/views/herbs/index.html.erb
+++ b/app/views/herbs/index.html.erb
@@ -69,6 +69,9 @@
       </div>
     <% end %>       <%# if の end %>
 
+    <%# ページネーション %>
+    <%= paginate @herbs %>
+
     <div class="flex justify-center space-y-3 mt-3 pt-2">
       <%# 管理者権限導入後に if current_user.admin? で制御予定 %>
       <%#= link_to "＋ 新規登録", new_herb_path, class: "btn-primary-lg" %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,4 @@
+<%= link_to "«", url,
+      class: "join-item btn btn-sm btn-inactive",
+      rel: "first",
+      remote: remote %>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,4 @@
+<%= link_to "»", url,
+      class: "join-item btn btn-sm btn-inactive",
+      rel: "last",
+      remote: remote %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,8 @@
+<span class="next">
+  <%= link_to_unless current_page.last?,
+        t('views.pagination.next').html_safe,
+        url,
+        class: "join-item btn btn-sm btn-inactive",
+        rel: "next",
+        remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,4 @@
+<%= link_to page, url,
+      class: "join-item btn btn-sm #{page.current? ? 'btn-active' : 'btn-inactive'}",
+      remote: remote,
+      rel: page.rel %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,15 @@
+<%= paginator.render do %>
+  <div class="join text-xs mt-6 mx-auto flex justify-center">
+    <nav class="pagination" role="navigation" aria-label="pager">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.display_tag? %>
+          <%= page_tag page %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </nav>
+  </div>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,8 @@
+<span class="prev">
+  <%= link_to_unless current_page.first?,
+        t('views.pagination.previous').html_safe,
+        url,
+        class: "join-item btn btn-sm btn-inactive",
+        rel: "prev",
+        remote: remote %>
+</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,7 @@
     <main class="container mx-auto mt-0 px-5 flex">
       <%= yield %>
     </main>
+    <%= yield :fixed_button %>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -43,6 +43,7 @@
           <% end %>
         <% end %>
       </div>
+      <%= paginate @recipes %>
     <% else %>
       <p class="text-herb-green-300 text-sm text-center py-8">公開されたブレンドはまだありません</p>
     <% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,59 +1,121 @@
 <div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-3 space-y-3 w-full">
 
-  <%# ブレンド研究一覧 %>
   <div class="max-w-lg w-full bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5">
+
+    <%# タイトル %>
     <div class="flex justify-center">
       <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
         <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">ブレンド一覧</h2>
       </div>
     </div>
 
-    <% if @recipes.any? %>
-      <div class="w-full space-y-3 px-4 mt-4">
-        <% @recipes.each do |recipe| %>
-          <%= link_to recipe_path(recipe), class: "block" do %>
-            <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
-              <div class="flex justify-between items-start mb-2">
-                <div class="flex items-center gap-2 min-w-0">
-                  <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
-                </div>
-                <% if recipe.drinking_log %>
-                  <div class="bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2">
-                    ★ <%= recipe.drinking_log.rating %> / 5
+    <%# ── 変更①: タブ切り替え ── %>
+    <% active_tab = params[:tab] == "my" ? "my" : "public" %>
+    <div class="herb-tab-group mt-4">
+      <%= link_to "みんなのブレンド", home_path(tab: "public"),
+            class: active_tab == "public" ? "tab-item-active" : "tab-item-inactive" %>
+      <%= link_to "自分のブレンド", home_path(tab: "my"),
+            class: active_tab == "my" ? "tab-item-active" : "tab-item-inactive" %>
+    </div>
+
+    <%# ── 変更②: タブに応じてコンテンツを切り替え ── %>
+    <% if active_tab == "public" %>
+
+      <%# みんなのブレンド（変更③: @recipes → @public_recipes） %>
+      <% if @public_recipes.any? %>
+        <div class="w-full space-y-3 px-4 mt-4">
+          <% @public_recipes.each do |recipe| %>
+            <%= link_to recipe_path(recipe), class: "block" do %>
+              <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+                <div class="flex justify-between items-start mb-2">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
                   </div>
-                <% else %>
-                  <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-1 rounded-full flex-shrink-0 ml-2">感想未入力</span>
-                <% end %>
-              </div>
-
-              <%# --- ハーブタグの表示（リンクを削除） --- %>
-              <div class="flex flex-wrap gap-1 mb-3">
-                <% recipe.recipe_herbs.each do |rh| %>
-                  <% if rh.herb %>
-                    <%# 【修正】link_to から span タグに変更 %>
-                    <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
-                  <% elsif rh.custom_herb_name.present? %>
-                    <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                  <% if recipe.drinking_log %>
+                    <div class="bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2">
+                      ★ <%= recipe.drinking_log.rating %> / 5
+                    </div>
                   <% end %>
-                <% end %>
-              </div>
+                </div>
 
-              <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
-                <span>by <%= recipe.user.name %></span>
-                <% if recipe.user_id == current_user.id %>
+                <div class="flex flex-wrap gap-1 mb-3">
+                  <% recipe.recipe_herbs.each do |rh| %>
+                    <% if rh.herb %>
+                      <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
+                    <% elsif rh.custom_herb_name.present? %>
+                      <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                    <% end %>
+                  <% end %>
+                </div>
+
+                <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
+                  <span>by <%= recipe.user.name %></span>
+                  <% if recipe.user_id == current_user.id %>
+                    <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">自分</span>
+                  <% end %>
+                  <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+
+        <%# 変更④: ページネーション %>
+        <%= paginate @public_recipes %>
+      <% else %>
+        <p class="text-herb-green-300 text-sm text-center py-4">公開されたブレンドはまだありません</p>
+      <% end %>
+
+    <% else %>
+
+      <%# 自分のブレンド（変更⑤: @my_recipes、非公開タグあり） %>
+      <% if @my_recipes.any? %>
+        <div class="w-full space-y-3 px-4 mt-4">
+          <% @my_recipes.each do |recipe| %>
+            <%= link_to recipe_path(recipe), class: "block" do %>
+              <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+                <div class="flex justify-between items-start mb-2">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
+                  </div>
+                  <% if recipe.drinking_log %>
+                    <div class="bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2">
+                      ★ <%= recipe.drinking_log.rating %> / 5
+                    </div>
+                  <% else %>
+                    <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-1 rounded-full flex-shrink-0 ml-2">感想未入力</span>
+                  <% end %>
+                </div>
+
+                <div class="flex flex-wrap gap-1 mb-3">
+                  <% recipe.recipe_herbs.each do |rh| %>
+                    <% if rh.herb %>
+                      <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
+                    <% elsif rh.custom_herb_name.present? %>
+                      <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                    <% end %>
+                  <% end %>
+                </div>
+
+                <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
+                  <span>by <%= recipe.user.name %></span>
                   <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">自分</span>
                   <% unless recipe.is_public? %>
-                    <span class="text-[10px] bg-white text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">非公開</span>
+                    <span class="text-[10px] bg-white text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0 border border-herb-green-200">非公開</span>
                   <% end %>
-                <% end %>
-                <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
+                  <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
+                </div>
               </div>
-            </div>
+            <% end %>
           <% end %>
-        <% end %>
-      </div>
-    <% else %>
-      <p class="text-herb-green-300 text-sm text-center py-4">研究データがまだありません<br>最初の一杯を記録しましょう</p>
+        </div>
+
+        <%# 変更⑥: ページネーション（param_name を my_page に分離） %>
+        <%= paginate @my_recipes, param_name: :my_page %>
+      <% else %>
+        <p class="text-herb-green-300 text-sm text-center py-4">研究データがまだありません<br>最初の一杯を記録しましょう</p>
+      <% end %>
+
     <% end %>
 
     <div class="pt-4 space-y-3 flex flex-col items-center">

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -118,9 +118,17 @@
 
     <% end %>
 
-    <div class="pt-4 space-y-3 flex flex-col items-center">
-      <%= link_to "ブレンド記録を作成する", new_recipe_path, class: "btn-primary-lg" %>
-    </div>
-  </div>
+  <%= content_for :fixed_button do %>
+    <%= link_to new_recipe_path,
+          class: "btn-fab",
+          title: "ブレンド記録を作成する",
+          data: { controller: "fab", action: "click->fab#toggle" } do %>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+          stroke-width="2" stroke="currentColor" class="w-7 h-7 flex-shrink-0">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+      </svg>
+      <span class="fab-text">ブレンド記録を作成する</span>
+    <% end %>
+  <% end %>
 
 </div>

--- a/app/views/tea_reviews/index.html.erb
+++ b/app/views/tea_reviews/index.html.erb
@@ -43,6 +43,7 @@
         <% end %>
         <% end %>
       </div>
+      <%= paginate @tea_reviews %>
       <% else %>
         <p class="text-herb-green-300 text-sm text-center py-4">レビューがまだありません<br>最初のレビューを登録しましょう</p>
       <% end %>

--- a/app/views/tea_reviews/index.html.erb
+++ b/app/views/tea_reviews/index.html.erb
@@ -48,9 +48,18 @@
         <p class="text-herb-green-300 text-sm text-center py-4">レビューがまだありません<br>最初のレビューを登録しましょう</p>
       <% end %>
 
-    <div class="pt-4 space-y-3 flex flex-col items-center">
-      <%= link_to "既製ブレンドを登録する", new_tea_review_path, class: "btn-primary-lg" %>
-    </div>
+    <%= content_for :fixed_button do %>
+      <%= link_to new_tea_review_path,
+            class: "btn-fab",
+            title: "既製ブレンドを登録する",
+            data: { controller: "fab", action: "click->fab#toggle" } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+            stroke-width="2" stroke="currentColor" class="w-7 h-7 flex-shrink-0">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+        </svg>
+        <span class="fab-text">既製ブレンドを登録する</span>
+      <% end %>
+    <% end %>
   </div>
 
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,4 @@
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  config.max_per_page = 50
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -67,3 +67,7 @@ ja:
         freshness: "さわやかさ"
         flowery: "花のような香り"
         impression: "感想"
+  views:
+    pagination:
+      previous: "前へ"
+      next: "次へ"


### PR DESCRIPTION
### 概要

ページ遷移の遅延改善と UX 向上を目的に、kaminari を使ったページネーションを各一覧画面に導入しました。
あわせて home 画面のブレンド一覧をタブ分割し、新規作成ボタンを FAB（フローティングアクションボタン）に刷新しました。

---

### 変更内容

#### ページネーション
- **kaminari gem** を導入し、daisyUI の `join` コンポーネントでページネーション UI を構築
- ページネーションの配色をアプリのデザイン（herb-green）に統一
- 対象画面：ハーブ図鑑 / ブレンド一覧（みんな・自分） / 既製品レビュー一覧

#### home 画面タブ分割
- 従来「公開レシピ OR 自分のレシピ」を混在表示していた一覧を **「みんなのブレンド」「自分のブレンド」** の2タブに分離
- それぞれ独立したページネーションを実装（`page` / `my_page` パラメータで干渉しない設計）

#### FAB ボタン
- 新規作成ボタンをフッター上・右下固定の FAB に変更
- **スマホ幅**：丸ボタン → 1回タップで楕円に展開してテキスト表示 → 2回タップで遷移
- **PC幅（768px以上）**：常に楕円ボタンで表示・1回クリックで即遷移
- Stimulus コントローラー（`fab_controller.js`）で制御

---

### 動作確認

- [ ] ハーブ図鑑・ブレンド一覧・既製品レビュー一覧でページ遷移できる
- [ ] home 画面のタブ切り替えが正常に動作する
- [ ] スマホ幅で FAB が展開 → 遷移の2ステップで動作する
- [ ] PC 幅で FAB が1クリックで遷移する
- [ ] 既存テスト（`bundle exec rspec`）がグリーン

### 関連issue
 Closes #66 