### PR TITLE
Refactor/ タグ関連のUIパーツ共通化と配色のリファクタリング

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -11,11 +11,15 @@
     --color-herb-green-400: #a7c99a;
     /* 入力フォーカス・追加ボタン */
     --color-herb-green-600: #89bc7b;
-    /* 風味タグ・確定ボタン */
+    /* ハーブタグ・確定ボタン */
     --color-herb-green-700: #3a5b52;
     /* ヘッダー・フッター・メインボタン・文字色 */
     --color-herb-yellow-400: #f6ad49;
+    /* 風味タグ */
+    --color-herb-blue-400: #66cccc;
     /* 効能タグ */
+    --color-herb-red-400: #f56565;
+    /* 禁忌・注意タグ */
     --color-herb-white: #ffffff;
 }
 
@@ -46,14 +50,34 @@
            flex items-start space-x-4 shadow-sm;
   }
 
-  /* ハーブ名タグ（緑） */
+  /* ハーブ名タグ */
   .tag-herb {
     @apply bg-herb-green-600 text-white text-xs px-3 py-1 rounded-full;
   }
 
-  /* 効能タグ（オレンジ） */
-  .tag-benefit {
+  /* 風味タグ（オレンジ） */
+  .tag-flavor {
     @apply bg-herb-yellow-400 text-white text-xs px-3 py-1 rounded-full;
+  }
+
+  /* 効能タグ（ブルー） */
+  .tag-benefit {
+    @apply bg-herb-blue-400 text-white text-xs px-3 py-1 rounded-full;
+  }
+
+  /* 禁忌・注意タグ（レッド） */
+  .tag-caution {
+    @apply bg-red-100 text-red-700 border border-red-400 text-xs px-3 py-1 rounded-full;
+  }
+
+  /* 評価タグ */
+  .rate-star {
+    @apply bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2;
+  }
+
+  /* 自分のブレンドにつけるタグ */
+  .my-blend-tag {
+    @apply text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0;
   }
 
   /* メインのアクションボタン（フローティングボタンなど） */
@@ -152,7 +176,7 @@
   .pagination .btn-inactive:hover {
     background-color: theme('colors.herb-green-100') !important;
   }
-}
+} /* end @layer components */
 
 @layer utilities {
   /* ここにユーティリティクラスを追加できます */

--- a/app/views/herbs/edit.html.erb
+++ b/app/views/herbs/edit.html.erb
@@ -50,7 +50,7 @@
               <%= check_box_tag "herb[flavor_tag_ids][]", tag.id,
                   @herb.flavor_tag_ids.include?(tag.id),
                   id: "flavor_tag_#{tag.id}" %>
-              <span class="tag-herb ml-1"><%= tag.name %></span>
+              <span class="tag-flavor ml-1"><%= tag.name %></span>
             </label>
           <% end %>
         </div>
@@ -87,7 +87,7 @@
                 <%= check_box_tag "herb[caution_tag_ids][]", tag.id,
                     @herb.caution_tag_ids.include?(tag.id),
                     id: "caution_tag_#{tag.id}" %>
-                <span class="bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full ml-1">
+                <span class="tag-caution ml-1">
                   ⚠ <%= tag.name %>
                 </span>
               </label>

--- a/app/views/herbs/index.html.erb
+++ b/app/views/herbs/index.html.erb
@@ -38,7 +38,7 @@
               <% if herb.flavor_tags.any? %>
                 <div class="flex flex-wrap gap-1 mt-1">
                   <% herb.flavor_tags.each do |tag| %>
-                    <span class="flex flex-wrap gap-1 tag-herb"><%= tag.name %></span>
+                    <span class="tag-flavor"><%= tag.name %></span>
                   <% end %>
                 </div>
               <% end %>
@@ -56,9 +56,7 @@
               <% if herb.caution_tags.any? %>
                 <div class="flex flex-wrap gap-1 mt-1">
                   <% herb.caution_tags.each do |tag| %>
-                    <span class="flex flex-wrap gap-1 bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
-                      ⚠ <%= tag.name %>
-                    </span>
+                    <span class="tag-caution">⚠ <%= tag.name %></span>
                   <% end %>
                 </div>
               <% end %>

--- a/app/views/herbs/new.html.erb
+++ b/app/views/herbs/new.html.erb
@@ -50,7 +50,7 @@
               <%= check_box_tag "herb[flavor_tag_ids][]", tag.id,
                   @herb.flavor_tag_ids.include?(tag.id),
                   id: "flavor_tag_#{tag.id}" %>
-              <span class="tag-herb ml-1"><%= tag.name %></span>
+              <span class="tag-flavor ml-1"><%= tag.name %></span>
             </label>
           <% end %>
         </div>
@@ -87,9 +87,7 @@
                 <%= check_box_tag "herb[caution_tag_ids][]", tag.id,
                     @herb.caution_tag_ids.include?(tag.id),
                     id: "caution_tag_#{tag.id}" %>
-                <span class="bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full ml-1">
-                  ⚠ <%= tag.name %>
-                </span>
+                <span class="tag-caution ml-1">⚠ <%= tag.name %></span>
               </label>
             <% end %>
           </div>

--- a/app/views/herbs/show.html.erb
+++ b/app/views/herbs/show.html.erb
@@ -24,7 +24,7 @@
         <p class="text-xs text-herb-green-700/50">風味</p>
         <div class="flex flex-wrap gap-1">
           <% @herb.flavor_tags.each do |tag| %>
-            <span class="flex flex-wrap gap-1 tag-herb"><%= tag.name %></span>
+            <span class="tag-flavor"><%= tag.name %></span>
           <% end %>
         </div>
       <% end %>
@@ -44,9 +44,7 @@
         <p class="text-xs text-herb-green-700/50">禁忌</p>
         <div class="flex flex-wrap gap-1">
           <% @herb.caution_tags.each do |tag| %>
-            <span class="flex flex-wrap gap-1 bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
-              ⚠ <%= tag.name %>
-            </span>
+            <span class="tag-caution">⚠ <%= tag.name %></span>
           <% end %>
         </div>
       <% end %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -19,7 +19,7 @@
                   <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
                 </div>
                 <% if recipe.drinking_log %>
-                  <div class="bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2">
+                  <div class="rate-star">
                     ★ <%= recipe.drinking_log.rating %> / 5
                   </div>
                 <% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -12,7 +12,7 @@
             作成日: <%= @recipe.brewed_at %><br>
             投稿者: <%= @recipe.user.name %>
                 <% if @recipe.user_id == current_user.id %>
-                  <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">自分</span>
+                  <span class="my-blend-tag">自分</span>
                   <%#本リリースで有効化: 非公開バッジ %>
                   <% unless @recipe.is_public? %>
                     <span class="text-[10px] bg-white text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">非公開</span>
@@ -44,7 +44,7 @@
                 <p class="text-xs text-herb-green-700/80 mb-1">風味</p>
                 <div class="flex flex-wrap gap-1">
                   <% all_flavor_tags.each do |tag| %>
-                    <span class="tag-herb"><%= tag.name %></span>
+                    <span class="tag-flavor"><%= tag.name %></span>
                   <% end %>
                 </div>
               </div>
@@ -64,9 +64,7 @@
                 <p class="text-xs text-herb-green-700/80 mb-1">禁忌・注意事項</p>
                 <div class="flex flex-wrap gap-1">
                   <% all_caution_tags.each do |tag| %>
-                    <span class="bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">
-                      ⚠ <%= tag.name %>
-                    </span>
+                    <span class="tag-caution">⚠ <%= tag.name %></span>
                   <% end %>
                 </div>
               </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -32,7 +32,7 @@
                     <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
                   </div>
                   <% if recipe.drinking_log %>
-                    <div class="bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2">
+                    <div class="rate-star">
                       ★ <%= recipe.drinking_log.rating %> / 5
                     </div>
                   <% end %>
@@ -51,7 +51,7 @@
                 <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
                   <span>by <%= recipe.user.name %></span>
                   <% if recipe.user_id == current_user.id %>
-                    <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">自分</span>
+                    <span class="my-blend-tag">自分</span>
                   <% end %>
                   <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
                 </div>
@@ -79,7 +79,7 @@
                     <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
                   </div>
                   <% if recipe.drinking_log %>
-                    <div class="bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2">
+                    <div class="rate-star">
                       ★ <%= recipe.drinking_log.rating %> / 5
                     </div>
                   <% else %>
@@ -99,7 +99,7 @@
 
                 <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
                   <span>by <%= recipe.user.name %></span>
-                  <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">自分</span>
+                  <span class="my-blend-tag">自分</span>
                   <% unless recipe.is_public? %>
                     <span class="text-[10px] bg-white text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0 border border-herb-green-200">非公開</span>
                   <% end %>

--- a/app/views/tea_reviews/index.html.erb
+++ b/app/views/tea_reviews/index.html.erb
@@ -18,7 +18,7 @@
               <p class="text-xs text-herb-green-700/80"><%= review.brand %></p>
               <p class="text-base font-bold text-herb-green-800"><%= review.name %></p>
             </div>
-            <div class="bg-yellow-100 text-yellow-700 text-sm px-2 py-1 rounded-full font-bold flex-shrink-0 ml-2">
+            <div class="rate-star">
               ★ <%= review.rating %> / 5
             </div>
           </div>
@@ -35,7 +35,7 @@
               <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
                 <span>by <%= review.user.name %></span>
                 <% if review.user_id == current_user.id %>
-                  <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">自分</span>
+                  <span class="my-blend-tag">自分</span>
                 <% end %>
                 <span class="ml-auto"><%= l review.created_at, format: :short %></span>
               </div>

--- a/app/views/tea_reviews/show.html.erb
+++ b/app/views/tea_reviews/show.html.erb
@@ -28,13 +28,13 @@
                   <span class="text-herb-green-700 text-xs select-none">›</span>
                   <div class="flex flex-wrap gap-1">
                     <% trh.herb.flavor_tags.each do |tag| %>
-                      <span class="tag-herb"><%= tag.name %></span>
+                      <span class="tag-flavor"><%= tag.name %></span>
                     <% end %>
                     <% trh.herb.functional_tags.each do |tag| %>
                       <span class="tag-benefit"><%= tag.name %></span>
                     <% end %>
                     <% trh.herb.caution_tags.each do |tag| %>
-                      <span class="bg-red-100 text-red-700 text-xs px-2 py-0.5 rounded-full">⚠ <%= tag.name %></span>
+                      <span class="tag-caution">⚠ <%= tag.name %></span>
                     <% end %> </div>
                 <% else %>
                   <span class="text-herb-green-800 font-medium"><%= trh.custom_herb_name %></span>
@@ -62,7 +62,7 @@
       <div class="flex justify-between items-center mb-3">
         <div class="flex items-center gap-3">
           <h3 class="text-lg font-bold text-herb-green-800">総合評価</h3>
-          <div class="bg-yellow-100 text-yellow-700 px-3 py-1 rounded-full text-md font-bold">
+          <div class="rate-star">
             ★ <%= @tea_review.rating %> / 5
           </div>
         </div>


### PR DESCRIPTION
## 概要
タグ（風味、効能、禁忌など）や評価バッジのスタイルをTailwind CSSのコンポーネントクラスとして抽出・共通化しました。

## 変更内容
- **スタイルの共通化**: `application.tailwind.css` に以下のクラスを定義しました。
  - `.tag-herb`: ハーブ名（緑）
  - `.tag-flavor`: 風味（イエロー）
  - `.tag-benefit`: 効能（ブルー）
  - `.tag-caution`: 禁忌・注意（赤枠/赤文字）
  - `.rate-star`: 評価レーティング（星）
  - `.my-blend-tag`: 「自分」のレシピを示すバッジ
- **Viewの修正**: 各View（Herbs, Recipes, TeaReviews, Home）でインラインで書いていたTailwindクラスを上記の共通クラスに置換しました。

## 意図
- **デザインの一貫性**: アプリ全体で同じ意味を持つ要素には同じスタイルが適用されるようにします。
- **保守性の向上**: 配色やパディングの変更が必要になった際、CSS一箇所の修正で全てのViewに反映されます。
- **コードの可読性**: View側の記述が `class="tag-flavor"` のように簡潔になり、何を表示しているのかが意図しやすくなります（セマンティックな命名）。

## 関連issue
Closes #140 