### PR TITLE
Feature/ パスワードリセット機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "letter_opener"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -61,10 +61,11 @@ group :test do
 end
 
 gem "tailwindcss-rails", "~> 4.4"
-gem 'devise'
-gem 'kaminari'
-gem "cloudinary"
+gem "devise", "~> 4.9"
+gem "kaminari", "~> 1.2"
+gem "cloudinary", "~> 2.0"
 gem 'activestorage-cloudinary-service'
+
 group :development, :test do
   gem "debug", ...
   gem "brakeman", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "cloudinary", "~> 2.0"
 gem "activestorage-cloudinary-service"
 
 group :development, :test do
-  gem "debug", ...
+  gem "debug", platforms: %i[ mri mswin mingw x64_mingw ], require: "debug/prelude"
   gem "brakeman", require: false
   gem "rubocop-rails-omakase", require: false
   gem "dotenv-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ end
 gem "tailwindcss-rails", "~> 4.4"
 gem "devise", "~> 4.9"
 gem "kaminari", "~> 1.2"
+gem "resend"
+gem "good_job"
 gem "cloudinary", "~> 2.0"
 gem "activestorage-cloudinary-service"
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-  gem "letter_opener"
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -16,16 +16,6 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem "cssbundling-rails"
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder"
-# Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mswin mingw x64_mingw jruby ]
@@ -35,7 +25,7 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
-gem 'active_storage_validations'
+gem "active_storage_validations"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -64,7 +54,7 @@ gem "tailwindcss-rails", "~> 4.4"
 gem "devise", "~> 4.9"
 gem "kaminari", "~> 1.2"
 gem "cloudinary", "~> 2.0"
-gem 'activestorage-cloudinary-service'
+gem "activestorage-cloudinary-service"
 
 group :development, :test do
   gem "debug", ...

--- a/Gemfile
+++ b/Gemfile
@@ -65,4 +65,9 @@ gem 'devise'
 gem 'kaminari'
 gem "cloudinary"
 gem 'activestorage-cloudinary-service'
-gem 'dotenv-rails', groups: [:development, :test]
+group :development, :test do
+  gem "debug", ...
+  gem "brakeman", require: false
+  gem "rubocop-rails-omakase", require: false
+  gem "dotenv-rails"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,11 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
@@ -389,7 +394,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jsbundling-rails
   kaminari (~> 1.2)
-  letter_opener
+  letter_opener_web
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -133,6 +134,8 @@ GEM
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -145,8 +148,22 @@ GEM
       net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-x86_64-linux-gnu)
+    fugit (1.12.2)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    good_job (4.19.0)
+      activejob (>= 6.1.0)
+      activerecord (>= 6.1.0)
+      concurrent-ruby (>= 1.3.1)
+      fugit (>= 1.11.0)
+      railties (>= 6.1.0)
+      thor (>= 1.0.0)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -203,6 +220,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
@@ -238,6 +257,7 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -287,6 +307,9 @@ GEM
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.3.0)
+      base64
+      httparty (>= 0.22.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -391,6 +414,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   dotenv-rails
+  good_job
   image_processing (~> 1.2)
   jsbundling-rails
   kaminari (~> 1.2)
@@ -398,6 +422,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
+  resend
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.5.1)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     cloudinary (2.4.4)
       faraday (>= 2.0.1, < 3.0.0)
       faraday-follow_redirects (~> 0.5)
@@ -118,10 +120,10 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (5.0.3)
+    devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 7.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     dotenv (3.2.0)
@@ -156,9 +158,6 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.14.1)
-      actionview (>= 7.0.0)
-      activesupport (>= 7.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.19.3)
@@ -175,6 +174,12 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
@@ -376,15 +381,15 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
-  cloudinary
+  cloudinary (~> 2.0)
   cssbundling-rails
   debug
-  devise
+  devise (~> 4.9)
   dotenv-rails
   image_processing (~> 1.2)
-  jbuilder
   jsbundling-rails
-  kaminari
+  kaminari (~> 1.2)
+  letter_opener
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAILER_FROM", "noreply@herb-recipe-lab.com")
   layout "mailer"
 end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,14 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワード再設定のリクエストを受け付けました。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>下記のリンクをクリックして、新しいパスワードを設定してください。</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= link_to 'パスワードを再設定する', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>このリンクの有効期限は <strong>6時間</strong> です。</p>
+
+<p>心当たりがない場合は、このメールを無視してください。<br>
+パスワードは変更されません。</p>
+
+<p>Herb Recipe Lab</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,41 @@
-<h2>Change your password</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <p><%= f.label :password, "New password" %></p>
-    <% if @minimum_password_length %>
-      <p><em>(<%= @minimum_password_length %> characters minimum)</em></p>
-    <% end %>
-    <p><%= f.password_field :password, autofocus: true, autocomplete: "new-password" %></p>
+<div class="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <h2 class="mt-6 text-center text-3xl font-bold text-gray-900">
+      新しいパスワードの設定
+    </h2>
   </div>
 
-  <div class="field">
-    <p><%= f.label :password_confirmation, "Confirm new password" %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :reset_password_token %>
 
-<%= render "devise/shared/links" %>
+        <div class="mb-4">
+          <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <% if @minimum_password_length %>
+            <p class="text-xs text-gray-500 mb-1"><%= @minimum_password_length %>文字以上で設定してください</p>
+          <% end %>
+          <%= f.password_field :password,
+              autofocus: true,
+              autocomplete: "new-password",
+              class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500" %>
+        </div>
+
+        <div class="mb-6">
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.password_field :password_confirmation,
+              autocomplete: "new-password",
+              class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500" %>
+        </div>
+
+        <div>
+          <%= f.submit "パスワードを変更する",
+              class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none cursor-pointer" %>
+        </div>
+      <% end %>
+
+    </div>
+  </div>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,41 +1,43 @@
-<div class="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-md">
-    <h2 class="mt-6 text-center text-3xl font-bold text-gray-900">
-      新しいパスワードの設定
-    </h2>
-  </div>
+<div class="w-full min-h-[calc(100svh-80px)] flex items-center justify-center px-4">
+  <div class="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-herb-green-100 p-8 md:p-10">
 
-  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+    <%# タイトル %>
+    <div class="flex justify-center mb-6">
+      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">パスワード変更</h2>
+      </div>
+    </div>
 
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <div class="flex-grow flex flex-col items-center justify-center px-4">
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "w-full space-y-8" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
         <%= f.hidden_field :reset_password_token %>
 
-        <div class="mb-4">
-          <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <div>
+          <%= f.label :password, "新しいパスワード", class: "block text-lg text-herb-green-700 mb-3 ml-1" %>
           <% if @minimum_password_length %>
-            <p class="text-xs text-gray-500 mb-1"><%= @minimum_password_length %>文字以上で設定してください</p>
+            <p class="text-sm text-herb-green-700/60 mb-2 ml-1"><%= @minimum_password_length %>文字以上</p>
           <% end %>
           <%= f.password_field :password,
               autofocus: true,
               autocomplete: "new-password",
-              class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500" %>
-        </div>
-
-        <div class="mb-6">
-          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <%= f.password_field :password_confirmation,
-              autocomplete: "new-password",
-              class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500" %>
+              placeholder: "Password",
+              class: "w-full p-3 border border-herb-green-100 rounded-xl focus:ring-2 focus:ring-herb-green-600 focus:border-transparent outline-none text-lg" %>
         </div>
 
         <div>
-          <%= f.submit "パスワードを変更する",
-              class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none cursor-pointer" %>
+          <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-lg text-herb-green-700 mb-3 ml-1" %>
+          <%= f.password_field :password_confirmation,
+              autocomplete: "new-password",
+              placeholder: "Password",
+              class: "w-full p-3 border border-herb-green-100 rounded-xl focus:ring-2 focus:ring-herb-green-600 focus:border-transparent outline-none text-lg" %>
+        </div>
+
+        <div class="pt-4 space-y-3 flex flex-col items-center">
+          <%= f.submit "パスワードを変更する", class: "btn-primary-lg w-full" %>
         </div>
       <% end %>
-
     </div>
+
   </div>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,38 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+<div class="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <h2 class="mt-6 text-center text-3xl font-bold text-gray-900">
+      パスワードの再設定
+    </h2>
+    <p class="mt-2 text-center text-sm text-gray-600">
+      登録済みのメールアドレスを入力してください。<br>
+      パスワード再設定用のメールをお送りします。
+    </p>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Send me password reset instructions" %>
-  </div>
-<% end %>
+  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+    <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
 
-<%= render "devise/shared/links" %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <div class="mb-4">
+          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.email_field :email,
+              autofocus: true,
+              autocomplete: "email",
+              class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500" %>
+        </div>
+
+        <div>
+          <%= f.submit "再設定メールを送る",
+              class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none cursor-pointer" %>
+        </div>
+      <% end %>
+
+      <div class="mt-6 text-center text-sm">
+        <%= link_to "ログインに戻る", new_user_session_path, class: "text-green-600 hover:text-green-500" %>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,38 +1,37 @@
-<div class="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-md">
-    <h2 class="mt-6 text-center text-3xl font-bold text-gray-900">
-      パスワードの再設定
-    </h2>
-    <p class="mt-2 text-center text-sm text-gray-600">
+<div class="w-full min-h-[calc(100svh-80px)] flex items-center justify-center px-4">
+  <div class="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-herb-green-100 p-8 md:p-10">
+
+    <%# タイトル %>
+    <div class="flex justify-center mb-6">
+      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">パスワード再設定</h2>
+      </div>
+    </div>
+
+    <p class="text-xs text-herb-green-700 text-center mb-8">
       登録済みのメールアドレスを入力してください。<br>
-      パスワード再設定用のメールをお送りします。
+      再設定用のメールをお送りします。
     </p>
-  </div>
 
-  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <div class="flex-grow flex flex-col items-center justify-center px-4">
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "w-full space-y-8" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
-        <div class="mb-4">
-          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block text-lg text-herb-green-700 mb-3 ml-1" %>
           <%= f.email_field :email,
               autofocus: true,
               autocomplete: "email",
-              class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500" %>
+              placeholder: "example@mail.com",
+              class: "w-full p-3 border border-herb-green-100 rounded-xl focus:ring-2 focus:ring-herb-green-600 focus:border-transparent outline-none text-lg" %>
         </div>
 
-        <div>
-          <%= f.submit "再設定メールを送る",
-              class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none cursor-pointer" %>
+        <div class="pt-4 space-y-3 flex flex-col items-center">
+          <%= f.submit "再設定メールを送る", class: "btn-primary-lg w-full" %>
+          <%= link_to "ログインに戻る", new_user_session_path, class: "btn-white-lg w-full" %>
         </div>
       <% end %>
-
-      <div class="mt-6 text-center text-sm">
-        <%= link_to "ログインに戻る", new_user_session_path, class: "text-green-600 hover:text-green-500" %>
-      </div>
-
     </div>
+
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,8 @@
 <%# 画面全体を中央寄せにするコンテナ %>
 <div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4 space-y-6 w-full">
     <%= render 'devise/shared/login_form' %>
+    <div class="mt-4 text-center text-sm">
+        <%= link_to "パスワードをお忘れですか？", new_user_password_path, class: "text-green-600 hover:text-green-500" %>
+    </div>
+
 </div>

--- a/app/views/devise/shared/_login_form.html.erb
+++ b/app/views/devise/shared/_login_form.html.erb
@@ -25,7 +25,4 @@
         <% end %>
     </div>
 
-  <%# <div class="text-center pt-2"> %>
-    <%# <%= link_to "パスワードをお忘れの方はこちら", new_password_path(resource_name), class: "text-herb-green-700 border-b border-herb-green-700 pb-0.5 hover:opacity-70 transition-opacity" %>
-  <%# </div> %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,6 @@ module Myapp
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     # config.eager_load_paths << Rails.root.join("extras")
+    config.active_job.queue_adapter = :good_job
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.perform_deliveries = true
 
   # Disable caching for Action Mailer templates even if Action Controller

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,8 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,6 +74,9 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :resend
+  config.action_mailer.default_url_options = { host: "herb-recipe-lab.onrender.com" }
+  config.good_job.execution_mode = :async
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/good_job.yml
+++ b/config/good_job.yml
@@ -1,0 +1,11 @@
+default: &default
+  queues: "*"
+  max_threads: 5
+  poll_interval: 30
+
+development:
+  <<: *default
+
+production:
+  <<: *default
+  execution_mode: async

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'noreply@herb-recipe-lab.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,1 @@
+Resend.api_key = ENV["RESEND_API_KEY"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   devise_for :users

--- a/db/migrate/20260604062715_create_good_jobs.rb
+++ b/db/migrate/20260604062715_create_good_jobs.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+class CreateGoodJobs < ActiveRecord::Migration[7.2]
+  def change
+    # Uncomment for Postgres v12 or earlier to enable gen_random_uuid() support
+    # enable_extension 'pgcrypto'
+
+    create_table :good_jobs, id: :uuid do |t|
+      t.text :queue_name
+      t.integer :priority
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :performed_at
+      t.datetime :finished_at
+      t.text :error
+
+      t.timestamps
+
+      t.uuid :active_job_id
+      t.text :concurrency_key
+      t.text :cron_key
+      t.uuid :retried_good_job_id
+      t.datetime :cron_at
+
+      t.uuid :batch_id
+      t.uuid :batch_callback_id
+
+      t.boolean :is_discrete
+      t.integer :executions_count
+      t.text :job_class
+      t.integer :error_event, limit: 2
+      t.text :labels, array: true
+      t.uuid :locked_by_id
+      t.datetime :locked_at
+      t.integer :lock_type, limit: 2
+    end
+
+    create_table :good_job_batches, id: :uuid do |t|
+      t.timestamps
+      t.text :description
+      t.jsonb :serialized_properties
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_discard
+      t.text :callback_queue_name
+      t.integer :callback_priority
+      t.datetime :enqueued_at
+      t.datetime :discarded_at
+      t.datetime :finished_at
+      t.datetime :jobs_finished_at
+    end
+
+    create_table :good_job_executions, id: :uuid do |t|
+      t.timestamps
+
+      t.uuid :active_job_id, null: false
+      t.text :job_class
+      t.text :queue_name
+      t.jsonb :serialized_params
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.text :error
+      t.integer :error_event, limit: 2
+      t.text :error_backtrace, array: true
+      t.uuid :process_id
+      t.interval :duration
+    end
+
+    create_table :good_job_processes, id: :uuid do |t|
+      t.timestamps
+      t.jsonb :state
+      t.integer :lock_type, limit: 2
+    end
+
+    create_table :good_job_settings, id: :uuid do |t|
+      t.timestamps
+      t.text :key
+      t.jsonb :value
+      t.index :key, unique: true
+    end
+
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
+    add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
+    add_index :good_jobs, [:active_job_id, :created_at], name: :index_good_jobs_on_active_job_id_and_created_at
+    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
+    add_index :good_jobs, [:concurrency_key, :created_at], name: :index_good_jobs_on_concurrency_key_and_created_at
+    add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)", name: :index_good_jobs_on_cron_key_and_created_at_cond
+    add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+    add_index :good_jobs, [:finished_at], where: "finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at_only
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup
+    add_index :good_jobs, [:batch_id], where: "batch_id IS NOT NULL"
+    add_index :good_jobs, [:batch_callback_id], where: "batch_callback_id IS NOT NULL"
+    add_index :good_jobs, :job_class, name: :index_good_jobs_on_job_class
+    add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)", name: :index_good_jobs_on_labels
+
+    add_index :good_job_executions, [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+    add_index :good_jobs, [:priority, :scheduled_at], order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL", name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked
+    add_index :good_jobs, [:priority, :scheduled_at, :id],
+                                                      where: "finished_at IS NULL", name: "index_good_jobs_on_priority_scheduled_at_unfinished"
+    add_index :good_jobs, [:queue_name, :scheduled_at, :id],
+                                                      where: "finished_at IS NULL", name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished"
+
+    add_index :good_jobs, :locked_by_id,
+      where: "locked_by_id IS NOT NULL", name: "index_good_jobs_on_locked_by_id"
+    add_index :good_job_executions, [:process_id, :created_at], name: :index_good_job_executions_on_process_id_and_created_at
+    add_index :good_jobs, [:priority, :scheduled_at, :id],
+      name: :index_good_jobs_for_candidate_dequeue_unlocked,
+      order: { priority: "ASC NULLS LAST", scheduled_at: :asc, id: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL"
+
+    add_index :good_jobs, :queue_name, name: :index_good_jobs_on_queue_name
+    add_index :good_jobs, :created_at, name: :index_good_jobs_on_created_at
+    add_index :good_jobs, :finished_at,
+      name: :index_good_jobs_on_discarded,
+      order: { finished_at: :desc },
+      where: "finished_at IS NOT NULL AND error IS NOT NULL"
+    add_index :good_jobs, [:scheduled_at, :queue_name], name: :index_good_jobs_on_scheduled_at_and_queue_name
+    add_index :good_jobs, :id,
+      name: :index_good_jobs_on_unfinished_or_errored,
+      where: "finished_at IS NULL OR error IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_30_161837) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_04_062715) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,106 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_30_161837) do
     t.bigint "recipe_id", null: false
     t.index ["functional_tag_id"], name: "index_functional_tags_recipes_on_functional_tag_id"
     t.index ["recipe_id"], name: "index_functional_tags_recipes_on_recipe_id"
+  end
+
+  create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "description"
+    t.jsonb "serialized_properties"
+    t.text "on_finish"
+    t.text "on_success"
+    t.text "on_discard"
+    t.text "callback_queue_name"
+    t.integer "callback_priority"
+    t.datetime "enqueued_at"
+    t.datetime "discarded_at"
+    t.datetime "finished_at"
+    t.datetime "jobs_finished_at"
+  end
+
+  create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id", null: false
+    t.text "job_class"
+    t.text "queue_name"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.integer "error_event", limit: 2
+    t.text "error_backtrace", array: true
+    t.uuid "process_id"
+    t.interval "duration"
+    t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
+  end
+
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "state"
+    t.integer "lock_type", limit: 2
+  end
+
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "key"
+    t.jsonb "value"
+    t.index ["key"], name: "index_good_job_settings_on_key", unique: true
+  end
+
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "queue_name"
+    t.integer "priority"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "performed_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "active_job_id"
+    t.text "concurrency_key"
+    t.text "cron_key"
+    t.uuid "retried_good_job_id"
+    t.datetime "cron_at"
+    t.uuid "batch_id"
+    t.uuid "batch_callback_id"
+    t.boolean "is_discrete"
+    t.integer "executions_count"
+    t.text "job_class"
+    t.integer "error_event", limit: 2
+    t.text "labels", array: true
+    t.uuid "locked_by_id"
+    t.datetime "locked_at"
+    t.integer "lock_type", limit: 2
+    t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
+    t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
+    t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
+    t.index ["concurrency_key", "created_at"], name: "index_good_jobs_on_concurrency_key_and_created_at"
+    t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["created_at"], name: "index_good_jobs_on_created_at"
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at_only", where: "(finished_at IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_on_discarded", order: :desc, where: "((finished_at IS NOT NULL) AND (error IS NOT NULL))"
+    t.index ["id"], name: "index_good_jobs_on_unfinished_or_errored", where: "((finished_at IS NULL) OR (error IS NOT NULL))"
+    t.index ["job_class"], name: "index_good_jobs_on_job_class"
+    t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
+    t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_for_candidate_dequeue_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_on_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["queue_name", "scheduled_at", "id"], name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
+    t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["queue_name"], name: "index_good_jobs_on_queue_name"
+    t.index ["scheduled_at", "queue_name"], name: "index_good_jobs_on_scheduled_at_and_queue_name"
+    t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
   create_table "herb_caution_tags", force: :cascade do |t|


### PR DESCRIPTION
## 概要

Deviseを使ったパスワードリセット機能を実装しました。
開発環境でのメール確認にはletter_opener_webを使用し、
本番環境ではResend（API方式）+ good_jobによる非同期送信で実装しています。

## 変更内容

### 機能実装
- パスワードリセット申請画面（`new.html.erb`）を日本語化・UIを統一
- 新しいパスワード入力画面（`edit.html.erb`）を日本語化・UIを統一
- パスワードリセットメール本文（`reset_password_instructions.html.erb`）を日本語化
- ログイン画面に「パスワードをお忘れですか？」リンクを追加

### メール送信設定
- 開発環境：`letter_opener_web` でブラウザ上でメールを確認できるよう設定
- 本番環境：Render の無料プランでは SMTP ポートが使えないため、Resend の API 方式を採用
- `good_job` を導入し、メール送信をバックグラウンド非同期処理（`execution_mode: async`）で実行

### Gem追加
- `letter_opener_web`：開発環境のメール確認用
- `resend`：本番環境のメール送信
- `good_job`：非同期ジョブ処理

### 設定変更
- `config/environments/development.rb`：letter_opener_web のメール設定を追加
- `config/environments/production.rb`：Resend API方式・good_job 非同期モードを設定
- `config/initializers/resend.rb`：Resend APIキーの初期化
- `config/good_job.yml`：good_job のキュー・スレッド・非同期モード設定
- `config/application.rb`：ActiveJob のキューアダプタを good_job に設定
- `config/routes.rb`：letter_opener_web のルーティングを development 環境のみに追加
- `app/mailers/application_mailer.rb`：送信元アドレスを環境変数で管理

## 動作確認

- [x] 開発環境でパスワードリセットメールの送信・受信（letter_opener_web）
- [x] メール内リンクからパスワード変更・ログインまでの一連のフローが動作すること
- [ ] 本番環境（Render）でのメール送信確認

## Render 環境変数の設定

| キー | 説明 |
|---|---|
| `RESEND_API_KEY` | Resend のAPIキー |
| `MAILER_FROM` | 送信元メールアドレス |

## 関連issue
Closes #73 #99 #100