### PR TITLE
パフォーマンス改善：ホーム画面クエリ最適化 & キャッシュ設定

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,17 +10,19 @@ class StaticPagesController < ApplicationController
   end
 
   def home
-    # みんなのブレンド（公開レシピ全件。自分のも含む）
-    @public_recipes = Recipe
-      .includes(:user, :drinking_log, recipe_herbs: :herb)
-      .public_recipes
-      .recent
-      .page(params[:page]).per(10)
+    @active_tab = params[:tab] == "my" ? "my" : "public"
 
-    # 自分のブレンド（非公開含む）
-    @my_recipes = current_user.recipes
-      .includes(:drinking_log, recipe_herbs: :herb)
-      .recent
-      .page(params[:my_page]).per(10)
+    if @active_tab == "public"
+      @public_recipes = Recipe
+        .includes(:user, :drinking_log, recipe_herbs: :herb)
+        .public_recipes
+        .recent
+        .page(params[:page]).per(10)
+    else
+      @my_recipes = current_user.recipes
+        .includes(:drinking_log, recipe_herbs: :herb)
+        .recent
+        .page(params[:my_page]).per(10)
+    end
   end
 end

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -23,6 +23,7 @@
       <% if @public_recipes.any? %>
         <div class="w-full space-y-3 px-4 mt-4">
           <% @public_recipes.each do |recipe| %>
+            <% cache [recipe, recipe.drinking_log, current_user.id] do %>
             <%= link_to recipe_path(recipe), class: "block" do %>
               <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
                 <div class="flex justify-between items-start mb-2">
@@ -54,6 +55,7 @@
                   <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
                 </div>
               </div>
+            <% end %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -9,17 +9,15 @@
       </div>
     </div>
 
-    <%# ── 変更①: タブ切り替え ── %>
-    <% active_tab = params[:tab] == "my" ? "my" : "public" %>
     <div class="herb-tab-group mt-4">
       <%= link_to "みんなのブレンド", home_path(tab: "public"),
-            class: active_tab == "public" ? "tab-item-active" : "tab-item-inactive" %>
+            class: @active_tab == "public" ? "tab-item-active" : "tab-item-inactive" %>
       <%= link_to "自分のブレンド", home_path(tab: "my"),
-            class: active_tab == "my" ? "tab-item-active" : "tab-item-inactive" %>
+            class: @active_tab == "my" ? "tab-item-active" : "tab-item-inactive" %>
     </div>
 
     <%# ── 変更②: タブに応じてコンテンツを切り替え ── %>
-    <% if active_tab == "public" %>
+    <% if @active_tab == "public" %>
 
       <%# みんなのブレンド（変更③: @recipes → @public_recipes） %>
       <% if @public_recipes.any? %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,6 +66,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 32.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque


### PR DESCRIPTION
## パフォーマンス改善：ホーム画面のDBクエリ削減とキャッシュ有効化

### 変更内容

**1. タブ未表示側のクエリを削除**
`home` アクションで両タブのクエリを常に実行していたのを、表示中タブのみに絞り込み。
タブ判定ロジックもビューからコントローラ（`@active_tab`）に移動。

**2. `memory_store` によるキャッシュの有効化**
`cache_store` 未設定で `perform_caching = true` が機能していなかったため設定を追加。
公開レシピカードにフラグメントキャッシュを導入。キャッシュキーに `recipe` / `drinking_log` / `current_user.id` を含め、更新時に自動無効化。

### 変更ファイル
- `config/environments/production.rb`
- `app/controllers/static_pages_controller.rb`
- `app/views/static_pages/home.html.erb`