### PR TITLE
独自ドメインの設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.hosts << "herb-recipe-lab.com"      # 独自ドメイン
+  config.hosts << "www.herb-recipe-lab.com"  # サブドメイン
+
   # Code is not reloaded between requests.
   config.enable_reloading = false
 


### PR DESCRIPTION
## 独自ドメインの設定

参考: https://zenn.dev/hisa_dev/articles/8f1fc9c6910b26

### 変更内容

**`config/environments/production.rb`**

独自ドメインへのアクセスを許可するため `config.hosts` にドメインを追加。

```ruby
config.hosts << "example.com"
config.hosts << "www.example.com"