### PR TITLE
onrender.com のサブドメインも許可リストに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,7 @@ Rails.application.configure do
 
   config.hosts << "herb-recipe-lab.com"      # 独自ドメイン
   config.hosts << "www.herb-recipe-lab.com"  # サブドメイン
+  config.hosts << "herb-recipe-lab.onrender.com" # Renderのデフォルトドメイン
 
   # Code is not reloaded between requests.
   config.enable_reloading = false


### PR DESCRIPTION
## 修正：`herb-recipe-lab.onrender.com` のホスト許可を追加

### 原因

`config.hosts` に独自ドメインを追加した際、Rails の仕様により
**リストに1つでも値が設定されると、未登録ホストはすべてブロックされる**ため、
Render のデフォルト URL `herb-recipe-lab.onrender.com` へのアクセスが遮断されていた。

### 変更内容

**`config/environments/production.rb`**

```ruby
# 変更前
config.hosts << "herb-recipe-lab.com"
config.hosts << "www.herb-recipe-lab.com"

# 変更後
config.hosts << "herb-recipe-lab.com"
config.hosts << "www.herb-recipe-lab.com"
config.hosts << "herb-recipe-lab.onrender.com"  # 追加