### PR TITLE
メール送信を Resend → Gmail SMTP に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ end
 gem "tailwindcss-rails", "~> 4.4"
 gem "devise", "~> 4.9"
 gem "kaminari", "~> 1.2"
-gem "resend"
 gem "good_job"
 gem "cloudinary", "~> 2.0"
 gem "activestorage-cloudinary-service"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
-    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -160,10 +159,6 @@ GEM
       fugit (>= 1.11.0)
       railties (>= 6.1.0)
       thor (>= 1.0.0)
-    httparty (0.24.2)
-      csv
-      mini_mime (>= 1.0.0)
-      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -220,8 +215,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
-    multi_xml (0.9.1)
-      bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
@@ -307,9 +300,6 @@ GEM
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
-    resend (1.3.0)
-      base64
-      httparty (>= 0.22.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -422,7 +412,6 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
-  resend
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,8 +79,19 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-  config.action_mailer.delivery_method = :resend
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "herb-recipe-lab.onrender.com",
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: "plain",
+    enable_starttls_auto: true
+  }
   config.action_mailer.default_url_options = { host: "herb-recipe-lab.onrender.com" }
+
   config.good_job.execution_mode = :async
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'noreply@herb-recipe-lab.com'
+  config.mailer_sender = ENV.fetch("MAILER_SENDER", "noreply@herb-recipe-lab.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch("MAILER_SENDER", "noreply@herb-recipe-lab.com")
+  config.mailer_sender = ENV.fetch("MAILER_SENDER")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,1 +1,0 @@
-Resend.api_key = ENV["RESEND_API_KEY"]


### PR DESCRIPTION
## メール送信を Resend → Gmail SMTP に変更

### 背景
Render Starter プランではメール送信ポート（587）が開放されているため、
外部サービス（Resend）を使わず Gmail SMTP で直接送信できる。

### 変更内容

#### `Gemfile`
- `gem "resend"` を削除

#### `config/initializers/resend.rb`
- ファイルごと削除（Resend の API キー設定が不要になったため）

#### `config/environments/production.rb`
- `delivery_method` を `:resend` → `:smtp` に変更
- Gmail SMTP 設定を追加（`smtp.gmail.com:587` / STARTTLS）
- 認証情報は ENV 変数（`MAILER_SENDER` / `MAILER_PASSWORD`）で管理

#### `config/initializers/devise.rb`
- `mailer_sender` を固定文字列から `ENV.fetch("MAILER_SENDER")` に変更
- Gmail SMTP では From アドレスが認証アカウントと一致する必要があるため

### Render への設定（デプロイ前に必須）
以下の環境変数を Render の Environment Variables に登録すること。

| Key | Value |
|-----|-------|
| `MAILER_SENDER` | 送信専用 Gmail アドレス |
| `MAILER_PASSWORD` | Gmail App Password（16桁） |

既存の `RESEND_API_KEY` は動作確認後に削除する。

### 動作確認
- [ ] パスワードリセット画面でメール送信を実行
- [ ] 送信専用 Gmail の送信済みトレイに記録があることを確認
- [ ] 受信メールのリセットリンクからパスワード変更が完了することを確認