### PR TITLE
ブックマーク機能の実装

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -2,9 +2,25 @@ class BookmarksController < ApplicationController
   before_action :require_login_with_alert
 
   def index
-    @bookmarks = current_user.bookmarks.includes(recipe: [:drinking_log, :user, recipe_herbs: :herb]).order(created_at: :desc)
-    # N+1対策: パーシャルで使う bookmarked_recipe_ids を一括取得
-    @bookmarked_recipe_ids = current_user.bookmarks.pluck(:recipe_id).to_set
+    @active_tab = params[:tab] == "my" ? "my" : "public"
+
+    if @active_tab == "public"
+      # 他人がブックマークしたレシピ（自分以外のレシピ）
+      @bookmarks = current_user.bookmarks
+                              .joins(:recipe)
+                              .where.not(recipes: { user_id: current_user.id })
+                              .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
+                              .order(created_at: :desc)
+                              .page(params[:page]).per(10)
+    else
+      # 自分のレシピのブックマーク
+      @bookmarks = current_user.bookmarks
+                              .joins(:recipe)
+                              .where(recipes: { user_id: current_user.id })
+                              .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
+                              .order(created_at: :desc)
+                              .page(params[:my_page]).per(10)
+    end
   end
 
   def create

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -2,5 +2,31 @@ class BookmarksController < ApplicationController
   before_action :require_login_with_alert
 
   def index
+    @bookmarks = current_user.bookmarks.includes(recipe: [:drinking_log, :user, recipe_herbs: :herb]).order(created_at: :desc)
+    # N+1対策: パーシャルで使う bookmarked_recipe_ids を一括取得
+    @bookmarked_recipe_ids = current_user.bookmarks.pluck(:recipe_id).to_set
+  end
+
+  def create
+    @recipe = Recipe.find(params[:recipe_id])
+    @bookmark = current_user.bookmarks.find_or_initialize_by(recipe: @recipe)
+    @bookmark.save
+    render_bookmark_turbo
+  end
+
+  def destroy
+    @bookmark = current_user.bookmarks.find(params[:id])
+    @recipe = @bookmark.recipe
+    @bookmark.destroy
+    render_bookmark_turbo
+  end
+
+  private
+
+  def render_bookmark_turbo
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: recipe_path(@recipe) }
+    end
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,6 +11,8 @@ class StaticPagesController < ApplicationController
 
   def home
     @active_tab = params[:tab] == "my" ? "my" : "public"
+    # bookmarks をオブジェクトごとロードしてビューで find できるようにする
+    @user_bookmarks = current_user.bookmarks.to_a
 
     if @active_tab == "public"
       @public_recipes = Recipe

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,6 @@
+class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :recipe
+
+  validates :user_id, uniqueness: { scope: :recipe_id }
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -4,6 +4,7 @@ class Recipe < ApplicationRecord
   has_many :recipe_herbs, dependent: :destroy
   has_many :herbs, through: :recipe_herbs
   has_one :drinking_log, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
 
   has_and_belongs_to_many :flavor_tags
   has_and_belongs_to_many :functional_tags

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   has_many :recipes, dependent: :destroy
   has_many :herbs, dependent: :nullify
   has_many :tea_reviews, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmarked_recipes, through: :bookmarks, source: :recipe
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/bookmarks/_button.html.erb
+++ b/app/views/bookmarks/_button.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (recipe:, bookmark:) %>
+<div id="bookmark_recipe_<%= recipe.id %>">
+  <% if bookmark %>
+    <%= button_to bookmark_path(bookmark),
+          method: :delete,
+          data: { turbo_stream: true },
+          class: "flex items-center gap-1 text-xs text-herb-green-600 bg-herb-green-50 px-3 py-1 rounded-full border border-herb-green-200 hover:bg-herb-green-100" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 fill-herb-green-600" viewBox="0 0 24 24">
+        <path d="M5 3h14a1 1 0 011 1v17.267a.5.5 0 01-.763.429L12 17.764l-7.237 3.932A.5.5 0 014 21.267V4a1 1 0 011-1z"/>
+      </svg>
+      保存済み
+    <% end %>
+  <% else %>
+    <%= button_to bookmarks_path,
+          params: { recipe_id: recipe.id },
+          method: :post,
+          data: { turbo_stream: true },
+          class: "flex items-center gap-1 text-xs text-herb-green-600 bg-white px-3 py-1 rounded-full border border-herb-green-200 hover:bg-herb-green-50" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3h14a1 1 0 011 1v17.267a.5.5 0 01-.763.429L12 17.764l-7.237 3.932A.5.5 0 014 21.267V4a1 1 0 011-1z"/>
+      </svg>
+      保存する
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bookmark_recipe_#{@recipe.id}" do %>
+  <%= render 'bookmarks/button', recipe: @recipe, bookmark: @bookmark %>
+<% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bookmark_recipe_#{@recipe.id}" do %>
+  <%= render 'bookmarks/button', recipe: @recipe, bookmark: nil %>
+<% end %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,9 +1,63 @@
-<div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4 w-full">
-  <div class="max-w-sm bg-white rounded-2xl shadow-sm border border-herb-green-100 p-12 flex flex-col items-center space-y-4 text-center">
-    <p class="text-4xl">🌿</p>
-    <p class="text-herb-green-700 font-medium text-lg">この機能はただいま育成中です🌿</p>
-    <br>
-    <p class="text-herb-green-600 text-sm">もうしばらくお待ちください</p>
-    <br>
+<%# app/views/bookmarks/index.html.erb %>
+<div class="min-h-screen bg-gradient-to-br from-herb-green-50 flex flex-col items-center p-3 w-full">
+
+  <div class="max-w-lg w-full bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5 my-5">
+
+    <%# タイトル %>
+    <div class="flex justify-center mb-6">
+      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">保存したレシピ</h2>
+      </div>
+    </div>
+
+    <% if @bookmarks.any? %>
+      <div class="w-full space-y-3 px-4 mt-4">
+        <% @bookmarks.each do |bookmark| %>
+          <% recipe = bookmark.recipe %>
+          <%= link_to recipe_path(recipe), class: "block" do %>
+            <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+              <div class="flex justify-between items-start mb-2">
+                <div class="flex items-center gap-2 min-w-0">
+                  <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
+                </div>
+                <% if recipe.drinking_log %>
+                  <div class="rate-star">
+                    ★ <%= recipe.drinking_log.rating %> / 5
+                  </div>
+                <% end %>
+                <%= render 'bookmarks/button', recipe: recipe, bookmark: bookmark %>
+              </div>
+
+              <div class="flex flex-wrap gap-1 mb-3">
+                <% recipe.recipe_herbs.each do |rh| %>
+                  <% if rh.herb %>
+                    <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
+                  <% elsif rh.custom_herb_name.present? %>
+                    <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                  <% end %>
+                <% end %>
+              </div>
+
+              <div class="flex justify-between items-center text-[10px] text-herb-green-700/80">
+                <span>by <%= recipe.user.name %></span>
+                <span><%= l recipe.created_at, format: :short %></span>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-herb-green-300 text-sm text-center py-8">保存したレシピはまだありません</p>
+    <% end %>
+
+    <%# レシピ探しへの誘導 %>
+    <div class="pt-6 flex flex-col items-center">
+      <%= link_to "みんなのブレンドを見る", recipes_path, class: "btn-primary-lg" %>
+    </div>
+
   </div>
+
+  <%= render 'shared/footer' %>
 </div>
+
+

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -4,30 +4,39 @@
   <div class="max-w-lg w-full bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5 my-5">
 
     <%# タイトル %>
-    <div class="flex justify-center mb-6">
+    <div class="flex justify-center mb-4">
       <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
         <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">保存したレシピ</h2>
       </div>
+    </div>
+
+    <%# タブ %>
+    <div class="herb-tab-group mt-4">
+      <%= link_to "みんなのブレンド", bookmarks_path(tab: "public"),
+            class: @active_tab == "public" ? "tab-item-active" : "tab-item-inactive" %>
+      <%= link_to "自分のブレンド", bookmarks_path(tab: "my"),
+            class: @active_tab == "my" ? "tab-item-active" : "tab-item-inactive" %>
     </div>
 
     <% if @bookmarks.any? %>
       <div class="w-full space-y-3 px-4 mt-4">
         <% @bookmarks.each do |bookmark| %>
           <% recipe = bookmark.recipe %>
-          <%= link_to recipe_path(recipe), class: "block" do %>
-            <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
-              <div class="flex justify-between items-start mb-2">
-                <div class="flex items-center gap-2 min-w-0">
-                  <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
-                </div>
+          <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+            <div class="flex justify-between items-start mb-2">
+              <%= link_to recipe_path(recipe), class: "flex items-center gap-2 min-w-0 flex-1" do %>
+                <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
+              <% end %>
+              <div class="flex items-center gap-2 flex-shrink-0">
                 <% if recipe.drinking_log %>
-                  <div class="rate-star">
-                    ★ <%= recipe.drinking_log.rating %> / 5
-                  </div>
+                  <div class="rate-star">★ <%= recipe.drinking_log.rating %> / 5</div>
                 <% end %>
+                <%# 自分のレシピも含めてブックマークボタンを表示 %>
                 <%= render 'bookmarks/button', recipe: recipe, bookmark: bookmark %>
               </div>
+            </div>
 
+            <%= link_to recipe_path(recipe) do %>
               <div class="flex flex-wrap gap-1 mb-3">
                 <% recipe.recipe_herbs.each do |rh| %>
                   <% if rh.herb %>
@@ -37,15 +46,25 @@
                   <% end %>
                 <% end %>
               </div>
-
-              <div class="flex justify-between items-center text-[10px] text-herb-green-700/80">
+              <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
                 <span>by <%= recipe.user.name %></span>
-                <span><%= l recipe.created_at, format: :short %></span>
+                <% if recipe.user == current_user %>
+                  <span class="my-blend-tag">自分</span>
+                <% end %>
+                <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         <% end %>
       </div>
+
+      <%# ページネーション（タブに応じてパラメータを切り替え） %>
+      <% if @active_tab == "public" %>
+        <%= paginate @bookmarks %>
+      <% else %>
+        <%= paginate @bookmarks, param_name: :my_page %>
+      <% end %>
+
     <% else %>
       <p class="text-herb-green-300 text-sm text-center py-8">保存したレシピはまだありません</p>
     <% end %>
@@ -54,5 +73,3 @@
 
   <%= render 'shared/footer' %>
 </div>
-
-

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -50,11 +50,6 @@
       <p class="text-herb-green-300 text-sm text-center py-8">保存したレシピはまだありません</p>
     <% end %>
 
-    <%# レシピ探しへの誘導 %>
-    <div class="pt-6 flex flex-col items-center">
-      <%= link_to "みんなのブレンドを見る", recipes_path, class: "btn-primary-lg" %>
-    </div>
-
   </div>
 
   <%= render 'shared/footer' %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -25,38 +25,47 @@
                 <% end %>
               </div>
 
-              <div class="flex flex-wrap gap-1 mb-3">
-                <% recipe.recipe_herbs.each do |rh| %>
-                  <% if rh.herb %>
-                    <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
-                  <% elsif rh.custom_herb_name.present? %>
-                    <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
-                  <% end %>
-                <% end %>
-              </div>
+    <% @public_recipes.each do |recipe| %>
+      <% bookmark = @user_bookmarks.find { |b| b.recipe_id == recipe.id } %>
+      <%# キャッシュキーにブックマーク状態を含める %>
+      <% cache [recipe, recipe.drinking_log, current_user.id, bookmark&.id] do %>
+        <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+          <div class="flex justify-between items-start mb-2">
+            <%= link_to recipe_path(recipe), class: "flex items-center gap-2 min-w-0 flex-1" do %>
+              <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
+            <% end %>
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <% if recipe.drinking_log %>
+                <div class="rate-star">★ <%= recipe.drinking_log.rating %> / 5</div>
+              <% end %>
+              <%# 他人のレシピにのみブックマークボタンを表示 %>
+              <% if recipe.user != current_user %>
+                <%= render 'bookmarks/button', recipe: recipe, bookmark: bookmark %>
+              <% end %>
+            </div>
+          </div>
 
-              <div class="flex justify-between items-center text-[10px] text-herb-green-700/80">
-                <span>by <%= recipe.user.name %></span>
-                <span><%= l recipe.created_at, format: :short %></span>
-              </div>
+          <%= link_to recipe_path(recipe) do %>
+            <div class="flex flex-wrap gap-1 mb-3">
+              <% recipe.recipe_herbs.each do |rh| %>
+                <% if rh.herb %>
+                  <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
+                <% elsif rh.custom_herb_name.present? %>
+                  <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                <% end %>
+              <% end %>
+            </div>
+            <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
+              <span>by <%= recipe.user.name %></span>
+              <% if recipe.user_id == current_user.id %>
+                <span class="my-blend-tag">自分</span>
+              <% end %>
+              <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
             </div>
           <% end %>
-        <% end %>
-      </div>
-      <%= paginate @recipes %>
-    <% else %>
-      <p class="text-herb-green-300 text-sm text-center py-8">公開されたブレンドはまだありません</p>
-    <% end %>
-
-    <%# ログイン誘導 %>
-    <div class="pt-6 flex flex-col items-center">
-      <% if user_signed_in? %>
-        <%= link_to "マイブレンドを見る", home_path, class: "btn-primary-lg" %>
-      <% else %>
-        <%= link_to "ログインして記録を始める", new_user_session_path, class: "btn-primary-lg" %>
+        </div>
       <% end %>
-    </div>
-
+    <% end %>
   </div>
 
   <%= render 'shared/footer' %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -26,6 +26,12 @@
             <%= link_to "削除", recipe_path(@recipe), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "text-xs bg-red-50 text-red-600 px-3 py-1 rounded-full border border-red-200 hover:bg-red-100" %>
           </div>
         <% end %>
+        <%# ログイン済み かつ 他人のレシピ のみ表示 %>
+        <% if user_signed_in? && @recipe.user != current_user %>
+          <%# N+1対策: showアクションでは単一レコードのため exists? を1回だけ呼ぶ %>
+          <% bookmark = current_user.bookmarks.find_by(recipe: @recipe) %>
+          <%= render 'bookmarks/button', recipe: @recipe, bookmark: bookmark %>
+        <% end %>
       </div>
 
     <%# ハーブ配合 & ブレンドの特徴 を横並び %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -6,32 +6,34 @@
     <div class="bg-white rounded-2xl shadow-sm border border-herb-green-100 p-6 md:p-8">
       <%# レシピ名・作成日・投稿者 %>
       <div class="flex justify-between items-start mb-4">
-        <div>
+
+        <%# 左側: タイトル・作成日・投稿者 %>
+        <div class="flex-1 min-w-0">
           <h1 class="text-2xl font-bold text-herb-green-800"><%= @recipe.title %></h1>
           <p class="text-xs text-herb-green-700/80 mt-1">
             作成日: <%= @recipe.brewed_at %><br>
             投稿者: <%= @recipe.user.name %>
                 <% if @recipe.user_id == current_user.id %>
                   <span class="my-blend-tag">自分</span>
-                  <%#本リリースで有効化: 非公開バッジ %>
                   <% unless @recipe.is_public? %>
                     <span class="text-[10px] bg-white text-herb-green-700/80 px-2 py-0.5 rounded-full flex-shrink-0">非公開</span>
                   <% end %>
                 <% end %>
           </p>
         </div>
-        <% if @recipe.user == current_user %>
-          <div class="flex gap-2">
+
+        <%# 右側: ボタン群をまとめて右寄せ %>
+        <div class="flex items-center gap-2 flex-shrink-0 ml-4">
+          <% if user_signed_in? %>
+            <% bookmark = current_user.bookmarks.find_by(recipe: @recipe) %>
+            <%= render 'bookmarks/button', recipe: @recipe, bookmark: bookmark %>
+          <% end %>
+          <% if @recipe.user == current_user %>
             <%= link_to "レシピ編集", edit_recipe_path(@recipe), class: "text-xs bg-herb-green-50 text-herb-green-600 px-3 py-1 rounded-full border border-herb-green-200 hover:bg-herb-green-100" %>
             <%= link_to "削除", recipe_path(@recipe), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "text-xs bg-red-50 text-red-600 px-3 py-1 rounded-full border border-red-200 hover:bg-red-100" %>
-          </div>
-        <% end %>
-        <%# ログイン済み かつ 他人のレシピ のみ表示 %>
-        <% if user_signed_in? && @recipe.user != current_user %>
-          <%# N+1対策: showアクションでは単一レコードのため exists? を1回だけ呼ぶ %>
-          <% bookmark = current_user.bookmarks.find_by(recipe: @recipe) %>
-          <%= render 'bookmarks/button', recipe: @recipe, bookmark: bookmark %>
-        <% end %>
+          <% end %>
+        </div>
+
       </div>
 
     <%# ハーブ配合 & ブレンドの特徴 を横並び %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -23,39 +23,44 @@
       <% if @public_recipes.any? %>
         <div class="w-full space-y-3 px-4 mt-4">
           <% @public_recipes.each do |recipe| %>
-            <% cache [recipe, recipe.drinking_log, current_user.id] do %>
-            <%= link_to recipe_path(recipe), class: "block" do %>
+            <% bookmark = @user_bookmarks.find { |b| b.recipe_id == recipe.id } %>
+            <% cache [recipe, recipe.drinking_log, current_user.id, bookmark&.id] do %>
               <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+
+                <%# タイトル行: リンクとボタンを横並び %>
                 <div class="flex justify-between items-start mb-2">
-                  <div class="flex items-center gap-2 min-w-0">
+                  <%= link_to recipe_path(recipe), class: "flex items-center gap-2 min-w-0 flex-1" do %>
                     <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
-                  </div>
-                  <% if recipe.drinking_log %>
-                    <div class="rate-star">
-                      ★ <%= recipe.drinking_log.rating %> / 5
-                    </div>
                   <% end %>
-                </div>
-
-                <div class="flex flex-wrap gap-1 mb-3">
-                  <% recipe.recipe_herbs.each do |rh| %>
-                    <% if rh.herb %>
-                      <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
-                    <% elsif rh.custom_herb_name.present? %>
-                      <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                  <div class="flex items-center gap-2 flex-shrink-0">
+                    <% if recipe.drinking_log %>
+                      <div class="rate-star">★ <%= recipe.drinking_log.rating %> / 5</div>
                     <% end %>
-                  <% end %>
+                    <%= render 'bookmarks/button', recipe: recipe, bookmark: bookmark %>
+                  </div>
                 </div>
 
-                <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
-                  <span>by <%= recipe.user.name %></span>
-                  <% if recipe.user_id == current_user.id %>
-                    <span class="my-blend-tag">自分</span>
-                  <% end %>
-                  <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
-                </div>
+                <%# ハーブタグ・投稿者はリンクにする %>
+                <%= link_to recipe_path(recipe) do %>
+                  <div class="flex flex-wrap gap-1 mb-3">
+                    <% recipe.recipe_herbs.each do |rh| %>
+                      <% if rh.herb %>
+                        <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
+                      <% elsif rh.custom_herb_name.present? %>
+                        <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                      <% end %>
+                    <% end %>
+                  </div>
+                  <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
+                    <span>by <%= recipe.user.name %></span>
+                    <% if recipe.user_id == current_user.id %>
+                      <span class="my-blend-tag">自分</span>
+                    <% end %>
+                    <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
+                  </div>
+                <% end %>
+
               </div>
-            <% end %>
             <% end %>
           <% end %>
         </div>
@@ -68,25 +73,28 @@
 
     <% else %>
 
-      <%# 自分のブレンド（変更⑤: @my_recipes、非公開タグあり） %>
+      <%# 自分のブレンド %>
       <% if @my_recipes.any? %>
         <div class="w-full space-y-3 px-4 mt-4">
           <% @my_recipes.each do |recipe| %>
-            <%= link_to recipe_path(recipe), class: "block" do %>
-              <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
-                <div class="flex justify-between items-start mb-2">
-                  <div class="flex items-center gap-2 min-w-0">
-                    <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
-                  </div>
-                  <% if recipe.drinking_log %>
-                    <div class="rate-star">
-                      ★ <%= recipe.drinking_log.rating %> / 5
-                    </div>
-                  <% else %>
-                    <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-1 rounded-full flex-shrink-0 ml-2">感想未入力</span>
-                  <% end %>
-                </div>
+            <% bookmark = @user_bookmarks.find { |b| b.recipe_id == recipe.id } %>
+            <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
 
+              <div class="flex justify-between items-start mb-2">
+                <%= link_to recipe_path(recipe), class: "flex items-center gap-2 min-w-0 flex-1" do %>
+                  <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
+                <% end %>
+                <div class="flex items-center gap-2 flex-shrink-0">
+                  <% if recipe.drinking_log %>
+                    <div class="rate-star">★ <%= recipe.drinking_log.rating %> / 5</div>
+                  <% else %>
+                    <span class="text-[10px] bg-herb-green-100 text-herb-green-700/80 px-2 py-1 rounded-full flex-shrink-0">感想未入力</span>
+                  <% end %>
+                  <%= render 'bookmarks/button', recipe: recipe, bookmark: bookmark %>
+                </div>
+              </div>
+
+              <%= link_to recipe_path(recipe) do %>
                 <div class="flex flex-wrap gap-1 mb-3">
                   <% recipe.recipe_herbs.each do |rh| %>
                     <% if rh.herb %>
@@ -96,7 +104,6 @@
                     <% end %>
                   <% end %>
                 </div>
-
                 <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
                   <span>by <%= recipe.user.name %></span>
                   <span class="my-blend-tag">自分</span>
@@ -105,12 +112,11 @@
                   <% end %>
                   <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
                 </div>
-              </div>
-            <% end %>
+              <% end %>
+            </div>
           <% end %>
         </div>
 
-        <%# 変更⑥: ページネーション（param_name を my_page に分離） %>
         <%= paginate @my_recipes, param_name: :my_page %>
       <% else %>
         <p class="text-herb-green-300 text-sm text-center py-4">研究データがまだありません<br>最初の一杯を記録しましょう</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,8 @@ Rails.application.routes.draw do
 
   get 'home', to: 'static_pages#home'
   get 'profile', to: 'profiles#show'
-  get 'bookmarks', to: 'bookmarks#index'
+
+  resources :bookmarks, only: [:index, :create, :destroy]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end

--- a/db/migrate/20260606164705_create_bookmarks.rb
+++ b/db/migrate/20260606164705_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :bookmarks, [:user_id, :recipe_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_04_062715) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_06_164705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_04_062715) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_bookmarks_on_recipe_id"
+    t.index ["user_id", "recipe_id"], name: "index_bookmarks_on_user_id_and_recipe_id", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "caution_tags", force: :cascade do |t|
@@ -309,6 +319,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_04_062715) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "bookmarks", "recipes"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "drinking_logs", "recipes"
   add_foreign_key "herb_caution_tags", "caution_tags"
   add_foreign_key "herb_caution_tags", "herbs"


### PR DESCRIPTION
## 概要
ブックマーク（お気に入り）機能の実装

## 背景
ユーザーが気に入ったレシピを保存・管理できる機能を作成する。
一覧画面から目的のレシピへ素早くアクセスできるようにする。

## 変更内容

- **bookmarks テーブルの作成**
  - `user_id`・`recipe_id` の複合ユニークインデックスで二重登録を防止
  - 外部キー制約でデータ整合性を保証

- **Bookmark モデルの作成**
  - User・Recipe とのアソシエーション設定
  - `uniqueness` バリデーションによる二重登録防止（DB・アプリ層の二重防衛）

- **ブックマーク登録・解除・一覧アクションの実装**

  | アクション | メソッド | URL | 説明 |
  |---|---|---|---|
  | index | GET | /bookmarks | ブックマーク一覧 |
  | create | POST | /bookmarks | ブックマーク登録 |
  | destroy | DELETE | /bookmarks/:id | ブックマーク解除 |

- **Turbo Stream によるボタン切り替え**
  - ページリロードなしに「保存する」↔「保存済み」をリアルタイムで切り替え
  - JS 無効環境向けに HTML フォールバックも対応

- **ブックマークボタンの設置箇所**
  - レシピ詳細（`/recipes/:id`）
  - ブレンド一覧（`/home`・`/home?tab=my`）
  - レシピ一覧（`/recipes`）

- **ブックマーク一覧ページ（`/bookmarks`）**
  - 「みんなのブレンド」「自分のブレンド」タブで切り替え表示
  - 各タブにページネーションを実装

- **N+1 対策**
  - `includes` で関連データを一括取得
  - `@user_bookmarks.to_a` をコントローラでロードし、ビュー内でのクエリ発行をゼロに
  - パーシャルへ `bookmark` オブジェクトを渡す設計

## 確認方法
1. 他人のレシピ詳細・一覧で「保存する」ボタンが表示されることを確認
2. ボタンクリックでリロードなしに「保存済み」へ切り替わることを確認（Turbo Stream）
3. フッターのブックマークアイコンから一覧ページへ遷移し、タブ切り替えが動作することを確認
4. 一覧ページからブックマーク解除できることを確認
5. 未ログインユーザーは `/bookmarks` アクセス時にログイン画面へリダイレクトされることを確認
6. ブックマーク済みレシピを削除後、一覧を開いてもエラーにならないことを確認

## 影響範囲
- `config/routes.rb`（ルーティングの変更）
- `app/models/user.rb` / `app/models/recipe.rb`（アソシエーションの追加）
- `app/views/recipes/show.html.erb`（ブックマークボタンの追加）
- `app/views/static_pages/home.html.erb`（ブックマークボタンの追加）
- `app/views/recipes/index.html.erb`（ブックマークボタンの追加）

## スクリーンショット
** レシピ詳細画面
| 実装前 | 実装後 |
| --- | --- |
| なし | [![Image from Gyazo](https://i.gyazo.com/77af662394638fbd8ee821b037be4b81.png)](https://gyazo.com/77af662394638fbd8ee821b037be4b81) |

** ブックマーク一覧ページ
| 実装前 | 実装後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/77602aaf495705a670066b09d6190b5a.png)](https://gyazo.com/77602aaf495705a670066b09d6190b5a) | [![Image from Gyazo](https://i.gyazo.com/8fb747f9851e016688f38fd8d2249850.png)](https://gyazo.com/8fb747f9851e016688f38fd8d2249850) |

## 関連 issue
Closes #67 #107 #108 #109