### PR TITLE
検索機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ echo ".env" >> .gitignore
 # Tools
 .claude/worktrees/
 .agent/development_log/
+.agent/development_plan/

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem "devise", "~> 4.9"
 # ページネーション
 gem "kaminari", "~> 1.2"
 
+# 検索機能
+gem "ransack"
+
 # 非同期ジョブ（PostgreSQL バックエンド）
 gem "good_job"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -412,6 +416,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,15 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :configure_ransack
+
+  helper_method :search_active?
+
+  # 検索条件（ransack の q[] もしくは独立パラメーター）が1つでも指定されているか
+  def search_active?
+    return true if params[:q]&.values&.any?(&:present?)
+
+    %i[herb_names flavor_names functional_categories functional_names exclude_caution_tags]
+      .any? { |key| Array(params[key]).any?(&:present?) }
+  end
 
   protected
 
@@ -16,10 +25,71 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 
-  def configure_ransack
-    Ransack.configure do |config|
-      config.sanitize_custom_scope_booleans = false
+  # ── リッチ絞り込みのまとめ適用 ──────────────────────────────
+  # Recipe / TeaReview のように配合ハーブ（has_many :herbs through）経由でタグが
+  # 紐づくモデル向け。ハーブAND・風味・効能・禁忌除外をまとめて適用する。
+  def apply_herb_based_filters(scope, model:)
+    scope = filter_by_herb_names(scope, model: model)
+    scope = filter_by_flavor_names(scope, model: model, tag_join: { herbs: :flavor_tags })
+    scope = filter_by_functional_categories(scope, model: model, tag_join: { herbs: :functional_tags })
+    filter_by_excluded_caution_tags(scope, model: model, tag_join: { herbs: :caution_tags })
+  end
+
+  # Herb 図鑑のようにタグが直結するモデル向け。
+  # ハーブAND・評価は存在しないため、風味・効能・禁忌除外のみ適用する。
+  def apply_herb_self_filters(scope)
+    scope = filter_by_flavor_names(scope, model: Herb, tag_join: :flavor_tags)
+    scope = filter_by_functional_categories(scope, model: Herb, tag_join: :functional_tags)
+    filter_by_excluded_caution_tags(scope, model: Herb, tag_join: :caution_tags)
+  end
+
+  # ── 個別フィルター（モデルと join 経路を受け取る） ──────────
+  # herb_names[] で AND 絞り込み（全ハーブを含むレコードのみ）。has_many :herbs 前提。
+  def filter_by_herb_names(scope, model:)
+    names = Array(params[:herb_names]).map(&:strip).reject(&:blank?)
+    names.each do |name|
+      ids = model.joins(:herbs).where(herbs: { name: name }).select(:id)
+      scope = scope.where(id: ids)
     end
+    scope
+  end
+
+  # exclude_caution_tags[] で除外検索（指定タグを持つレコードを除外）
+  def filter_by_excluded_caution_tags(scope, model:, tag_join:)
+    names = Array(params[:exclude_caution_tags]).map(&:strip).reject(&:blank?)
+    return scope if names.empty?
+
+    excluded_ids = model.joins(tag_join).where(caution_tags: { name: names }).select(:id)
+    scope.where.not(id: excluded_ids)
+  end
+
+  # flavor_names[] で AND 絞り込み（最大2件、全ての風味を持つレコードのみ）
+  def filter_by_flavor_names(scope, model:, tag_join:)
+    names = Array(params[:flavor_names]).map(&:strip).reject(&:blank?).first(2)
+    names.each do |name|
+      ids = model.joins(tag_join).where(flavor_tags: { name: name }).select(:id)
+      scope = scope.where(id: ids)
+    end
+    scope
+  end
+
+  # functional_categories[] / functional_names[] による効能絞り込み（ペアごとに AND 検索）
+  # 各ペアについて functional_names[i] 指定時はそのタグ、未指定で functional_categories[i] 指定時はその分類に属する全タグを OR 検索
+  def filter_by_functional_categories(scope, model:, tag_join:)
+    categories = Array(params[:functional_categories])
+    names      = Array(params[:functional_names])
+
+    categories.each_with_index do |category, i|
+      category = category.to_s.strip
+      name     = names[i].to_s.strip
+      next if category.blank? && name.blank?
+
+      tag_names = name.present? ? [name] : (FunctionalTag::CATEGORIES[category] || [])
+      ids = model.joins(tag_join).where(functional_tags: { name: tag_names }).select(:id)
+      scope = scope.where(id: ids)
+    end
+
+    scope
   end
 
   def after_sign_up_path_for(resource)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :configure_ransack
 
   protected
 
@@ -13,6 +14,12 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     # サインアップ時に name カラムの保存を許可する
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
+
+  def configure_ransack
+    Ransack.configure do |config|
+      config.sanitize_custom_scope_booleans = false
+    end
   end
 
   def after_sign_up_path_for(resource)

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -8,22 +8,22 @@ class BookmarksController < ApplicationController
                        .where(bookmarks: { user_id: current_user.id })
 
     if @active_tab == "public"
-      # 他人がブックマークしたレシピ（自分以外のレシピ）
       @q = base_scope.where.not(user_id: current_user.id).ransack(params[:q])
+      filtered_ids = apply_herb_based_filters(Recipe.where(id: @q.result.select(:id)), model: Recipe).select(:id)
       @bookmarks = current_user.bookmarks
                                .joins(:recipe)
                                .where.not(recipes: { user_id: current_user.id })
-                               .where(recipe_id: @q.result(distinct: true).select(:id))
+                               .where(recipe_id: filtered_ids)
                                .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
                                .order(created_at: :desc)
                                .page(params[:page]).per(10)
     else
-      # 自分のレシピのブックマーク
       @q = base_scope.where(user_id: current_user.id).ransack(params[:q])
+      filtered_ids = apply_herb_based_filters(Recipe.where(id: @q.result.select(:id)), model: Recipe).select(:id)
       @bookmarks = current_user.bookmarks
                                .joins(:recipe)
                                .where(recipes: { user_id: current_user.id })
-                               .where(recipe_id: @q.result(distinct: true).select(:id))
+                               .where(recipe_id: filtered_ids)
                                .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
                                .order(created_at: :desc)
                                .page(params[:my_page]).per(10)

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -4,22 +4,29 @@ class BookmarksController < ApplicationController
   def index
     @active_tab = params[:tab] == "my" ? "my" : "public"
 
+    base_scope = Recipe.joins(:bookmarks)
+                       .where(bookmarks: { user_id: current_user.id })
+
     if @active_tab == "public"
       # 他人がブックマークしたレシピ（自分以外のレシピ）
+      @q = base_scope.where.not(user_id: current_user.id).ransack(params[:q])
       @bookmarks = current_user.bookmarks
-                              .joins(:recipe)
-                              .where.not(recipes: { user_id: current_user.id })
-                              .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
-                              .order(created_at: :desc)
-                              .page(params[:page]).per(10)
+                               .joins(:recipe)
+                               .where.not(recipes: { user_id: current_user.id })
+                               .where(recipe_id: @q.result(distinct: true).select(:id))
+                               .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
+                               .order(created_at: :desc)
+                               .page(params[:page]).per(10)
     else
       # 自分のレシピのブックマーク
+      @q = base_scope.where(user_id: current_user.id).ransack(params[:q])
       @bookmarks = current_user.bookmarks
-                              .joins(:recipe)
-                              .where(recipes: { user_id: current_user.id })
-                              .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
-                              .order(created_at: :desc)
-                              .page(params[:my_page]).per(10)
+                               .joins(:recipe)
+                               .where(recipes: { user_id: current_user.id })
+                               .where(recipe_id: @q.result(distinct: true).select(:id))
+                               .includes(recipe: [:drinking_log, :user, recipe_herbs: :herb])
+                               .order(created_at: :desc)
+                               .page(params[:my_page]).per(10)
     end
   end
 

--- a/app/controllers/herbs_controller.rb
+++ b/app/controllers/herbs_controller.rb
@@ -4,12 +4,23 @@ class HerbsController < ApplicationController
   before_action :set_tags, only: [:new, :create, :edit, :update]
   before_action :authorize_herb!, only: [:edit, :update, :destroy]
 
+  def autocomplete
+    query      = params[:q].to_s
+    normalized = query.tr('ぁ-ん', 'ァ-ン')  # ひらがな→カタカナに変換
+    herbs = if normalized.blank?
+      Herb.order(:name).limit(50)
+    else
+      Herb.where("name ILIKE ?", "%#{normalized}%").order(:name).limit(10)
+    end
+    render json: herbs.pluck(:name)
+  end
+
   def index
     @q = Herb.ransack(params[:q])
-    @herbs = @q.result(distinct: true)
-               .includes(:flavor_tags, :functional_tags, :caution_tags)
-               .order(:name)
-               .page(params[:page]).per(15)
+    @herbs = apply_herb_self_filters(Herb.where(id: @q.result.select(:id)))
+                 .includes(:flavor_tags, :functional_tags, :caution_tags)
+                 .order(:name)
+                 .page(params[:page]).per(15)
   end
 
   def show

--- a/app/controllers/herbs_controller.rb
+++ b/app/controllers/herbs_controller.rb
@@ -5,9 +5,11 @@ class HerbsController < ApplicationController
   before_action :authorize_herb!, only: [:edit, :update, :destroy]
 
   def index
-    @herbs = Herb.order(:name)
-                  .includes(:flavor_tags, :functional_tags, :caution_tags)
-                  .page(params[:page]).per(15)
+    @q = Herb.ransack(params[:q])
+    @herbs = @q.result(distinct: true)
+               .includes(:flavor_tags, :functional_tags, :caution_tags)
+               .order(:name)
+               .page(params[:page]).per(15)
   end
 
   def show

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -4,10 +4,12 @@ class RecipesController < ApplicationController
 
   def index
     @q = Recipe.public_recipes.ransack(params[:q])
-    @recipes = @q.result(distinct: true)
+    base = apply_herb_based_filters(Recipe.public_recipes.where(id: @q.result.select(:id)), model: Recipe)
+    @recipes = base
       .includes(:user, :drinking_log, recipe_herbs: :herb)
       .recent
       .page(params[:page]).per(10)
+    @user_bookmarks = user_signed_in? ? current_user.bookmarks.where(recipe: @recipes).to_a : []
   end
 
   def new

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -3,11 +3,11 @@ class RecipesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @recipes = Recipe
+    @q = Recipe.public_recipes.ransack(params[:q])
+    @recipes = @q.result(distinct: true)
       .includes(:user, :drinking_log, recipe_herbs: :herb)
-      .public_recipes  # ← where(is_public: true) からスコープに変更
-      .recent          # ← order(created_at: :desc) からスコープに変更
-      .page(params[:page]).per(10)  # ← ページネーション追加
+      .recent
+      .page(params[:page]).per(10)
   end
 
   def new

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,20 +11,24 @@ class StaticPagesController < ApplicationController
 
   def home
     @active_tab = params[:tab] == "my" ? "my" : "public"
-    # bookmarks をオブジェクトごとロードしてビューで find できるようにする
-    @user_bookmarks = current_user.bookmarks.to_a
 
     if @active_tab == "public"
-      @public_recipes = Recipe
+      @q = Recipe.public_recipes.ransack(params[:q])
+      base = apply_herb_based_filters(Recipe.public_recipes.where(id: @q.result.select(:id)), model: Recipe)
+      @public_recipes = base
         .includes(:user, :drinking_log, recipe_herbs: :herb)
-        .public_recipes
         .recent
         .page(params[:page]).per(10)
     else
-      @my_recipes = current_user.recipes
-        .includes(:drinking_log, recipe_herbs: :herb)
+      @q = current_user.recipes.ransack(params[:q])
+      base = apply_herb_based_filters(current_user.recipes.where(id: @q.result.select(:id)), model: Recipe)
+      @my_recipes = base
+        .includes(:user, :drinking_log, recipe_herbs: :herb)
         .recent
         .page(params[:my_page]).per(10)
     end
+
+    loaded_recipes = @public_recipes || @my_recipes || []
+    @user_bookmarks = current_user.bookmarks.where(recipe: loaded_recipes).to_a
   end
 end

--- a/app/controllers/tea_reviews_controller.rb
+++ b/app/controllers/tea_reviews_controller.rb
@@ -4,8 +4,9 @@ class TeaReviewsController < ApplicationController
 
   def index
     @q = current_user.tea_reviews.ransack(params[:q])
-    @tea_reviews = @q.result(distinct: true)
-      .includes(:herbs).order(created_at: :desc)
+    base = apply_herb_based_filters(current_user.tea_reviews.where(id: @q.result.select(:id)), model: TeaReview)
+    @tea_reviews = base
+      .includes(:herbs, :user).order(created_at: :desc)
       .page(params[:page]).per(10)
   end
 

--- a/app/controllers/tea_reviews_controller.rb
+++ b/app/controllers/tea_reviews_controller.rb
@@ -3,7 +3,8 @@ class TeaReviewsController < ApplicationController
   before_action :set_tea_review, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tea_reviews = current_user.tea_reviews
+    @q = current_user.tea_reviews.ransack(params[:q])
+    @tea_reviews = @q.result(distinct: true)
       .includes(:herbs).order(created_at: :desc)
       .page(params[:page]).per(10)
   end

--- a/app/javascript/controllers/checkbox_limit_controller.js
+++ b/app/javascript/controllers/checkbox_limit_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { max: Number }
+
+  limit(event) {
+    const checked = this.element.querySelectorAll("input[type=checkbox]:checked")
+    if (checked.length > this.maxValue) {
+      event.currentTarget.checked = false
+    }
+  }
+}

--- a/app/javascript/controllers/functional_category_controller.js
+++ b/app/javascript/controllers/functional_category_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["category", "name"]
+  static values = { categories: Object }
+
+  change() {
+    const category = this.categoryTarget.value
+    const names = this.categoriesValue[category] || []
+    this.nameTarget.innerHTML = '<option value="">指定なし（分類全体）</option>' +
+      names.map((n) => `<option value="${n}">${n}</option>`).join("")
+  }
+}

--- a/app/javascript/controllers/herb_search_controller.js
+++ b/app/javascript/controllers/herb_search_controller.js
@@ -1,0 +1,120 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["fieldList", "template"]
+
+  connect() {
+    this._onClickOutside = this._handleClickOutside.bind(this)
+    document.addEventListener("click", this._onClickOutside)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._onClickOutside)
+  }
+
+  _handleClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this._hideAllDropdowns()
+    }
+  }
+
+  // ── 入力補完（キー入力） ──────────────────────────────
+  async suggest(event) {
+    const input = event.currentTarget
+    const query = input.value.trim()
+    const dropdown = input.closest(".herb-field").querySelector(".herb-suggestions")
+
+    if (query.length === 0) {
+      this.hideDropdown(dropdown)
+      return
+    }
+
+    await this._fetchAndShow(query, dropdown)
+  }
+
+  // ── ▼ ボタン：全件トグル表示 ─────────────────────────
+  async showAll(event) {
+    event.preventDefault()
+    const field    = event.currentTarget.closest(".herb-field")
+    const dropdown = field.querySelector(".herb-suggestions")
+
+    if (!dropdown.classList.contains("hidden")) {
+      this.hideDropdown(dropdown)
+      return
+    }
+
+    const input = field.querySelector("input[type=text]")
+    await this._fetchAndShow(input.value.trim(), dropdown)
+  }
+
+  async _fetchAndShow(query, dropdown) {
+    const res   = await fetch(`/herbs/autocomplete?q=${encodeURIComponent(query)}`)
+    const names = await res.json()
+
+    if (names.length === 0) {
+      this.hideDropdown(dropdown)
+      return
+    }
+
+    dropdown.innerHTML = names
+      .map(name => `<li
+          class="px-3 py-2 text-sm text-white hover:bg-herb-green-700 cursor-pointer border-b border-herb-green-500/30 last:border-b-0"
+          data-name="${name}"
+          data-action="mousedown->herb-search#select">
+          ${name}
+        </li>`)
+      .join("")
+    dropdown.classList.remove("hidden")
+  }
+
+  // Esc キーで閉じる
+  keydown(event) {
+    if (event.key === "Escape") {
+      this._hideAllDropdowns()
+    }
+  }
+
+  select(event) {
+    const name  = event.currentTarget.dataset.name
+    const field = event.currentTarget.closest(".herb-field")
+    field.querySelector("input[type=text]").value = name
+    this.hideDropdown(field.querySelector(".herb-suggestions"))
+  }
+
+  hideDropdown(dropdown) {
+    if (dropdown) {
+      dropdown.innerHTML = ""
+      dropdown.classList.add("hidden")
+    }
+  }
+
+  _hideAllDropdowns() {
+    this.element.querySelectorAll(".herb-suggestions").forEach(d => this.hideDropdown(d))
+  }
+
+  blur(event) {
+    setTimeout(() => {
+      const dropdown = event.currentTarget.closest(".herb-field")?.querySelector(".herb-suggestions")
+      this.hideDropdown(dropdown)
+    }, 150)
+  }
+
+  // ── フィールド追加/削除 ───────────────────────────────
+  addField(event) {
+    event.preventDefault()
+    const clone = this.templateTarget.content.cloneNode(true)
+    this.fieldListTarget.appendChild(clone)
+  }
+
+  removeField(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    const field = event.currentTarget.closest(".herb-field")
+    if (this.fieldListTarget.querySelectorAll(".herb-field").length > 1) {
+      field.remove()
+    } else {
+      field.querySelector("input[type=text]").value = ""
+      this.hideDropdown(field.querySelector(".herb-suggestions"))
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,18 @@ application.register("hello", HelloController)
 
 import ToggleRadioController from "./toggle_radio_controller"
 application.register("toggle-radio", ToggleRadioController)
+
+import SeachToggleController from "./seach_toggle_controller"
+application.register("search-toggle", SeachToggleController)
+
+import HerbSearchController from "./herb_search_controller"
+application.register("herb-search", HerbSearchController)
+
+import TagFieldController from "./tag_field_controller"
+application.register("tag-field", TagFieldController)
+
+import CheckboxLimitController from "./checkbox_limit_controller"
+application.register("checkbox-limit", CheckboxLimitController)
+
+import FunctionalCategoryController from "./functional_category_controller"
+application.register("functional-category", FunctionalCategoryController)

--- a/app/javascript/controllers/seach_toggle_controller.js
+++ b/app/javascript/controllers/seach_toggle_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["form"];
+
+  connect() {
+    this._onClickOutside = this._handleClickOutside.bind(this);
+    document.addEventListener("click", this._onClickOutside);
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._onClickOutside);
+  }
+
+  toggle() {
+    this.formTarget.classList.toggle("hidden");
+  }
+
+  _handleClickOutside(event) {
+    if (!this.formTarget.classList.contains("hidden") && !this.element.contains(event.target)) {
+      this.formTarget.classList.add("hidden");
+    }
+  }
+}

--- a/app/javascript/controllers/tag_field_controller.js
+++ b/app/javascript/controllers/tag_field_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["fieldList", "template"]
+
+  addField(event) {
+    event.preventDefault()
+    const clone = this.templateTarget.content.cloneNode(true)
+    this.fieldListTarget.appendChild(clone)
+  }
+
+  removeField(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    const field = event.currentTarget.closest(".tag-field")
+    if (this.fieldListTarget.querySelectorAll(".tag-field").length > 1) {
+      field.remove()
+    } else {
+      field.querySelectorAll("select").forEach((select) => {
+        select.value = ""
+        select.dispatchEvent(new Event("change", { bubbles: true }))
+      })
+    }
+  }
+}

--- a/app/models/caution_tag.rb
+++ b/app/models/caution_tag.rb
@@ -7,6 +7,10 @@ class CautionTag < ApplicationRecord
     "相互作用"       => ["薬剤服用中注意", "抗凝固薬注意", "過剰摂取注意"]
   }.freeze
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
   def self.grouped_by_category
     all_tags = all.index_by(&:name)
     CATEGORIES.transform_values do |names|

--- a/app/models/drinking_log.rb
+++ b/app/models/drinking_log.rb
@@ -1,6 +1,10 @@
 class DrinkingLog < ApplicationRecord
   belongs_to :recipe
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[rating]
+  end
+
   # 風味タグ名（seeds.rb）とDBカラム名のマッピング
   FLAVOR_MAPPING = {
     "甘味" => :sweetness,

--- a/app/models/flavor_tag.rb
+++ b/app/models/flavor_tag.rb
@@ -1,2 +1,5 @@
 class FlavorTag < ApplicationRecord
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
 end

--- a/app/models/functional_tag.rb
+++ b/app/models/functional_tag.rb
@@ -8,6 +8,10 @@ class FunctionalTag < ApplicationRecord
     "活力・疲労"   => ["疲労回復", "眼精疲労サポート", "滋養補給"]
   }.freeze
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
   def self.grouped_by_category
     all_tags = all.index_by(&:name)
     CATEGORIES.transform_values do |names|

--- a/app/models/herb.rb
+++ b/app/models/herb.rb
@@ -15,6 +15,14 @@ class Herb < ApplicationRecord
 
   ACCEPTED_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[flavor_tags functional_tags caution_tags recipe_herbs]
+  end
+
   validates :name, presence: true, uniqueness: true
   validates :image,
     content_type: ACCEPTED_CONTENT_TYPES,

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -21,4 +21,12 @@ class Recipe < ApplicationRecord
     where("is_public = ? OR user_id = ?", true, user.id)
   }
   scope :recent, -> { order(created_at: :desc) }
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[title created_at]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[recipe_herbs user drinking_log flavor_tags functional_tags]
+  end
 end

--- a/app/models/recipe_herb.rb
+++ b/app/models/recipe_herb.rb
@@ -2,6 +2,14 @@ class RecipeHerb < ApplicationRecord
   belongs_to :recipe
   belongs_to :herb, optional: true
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[custom_herb_name]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[herb]
+  end
+
   # seeds.rbのunit設計に合わせた定義
   enum :unit, { teaspoon: 0, tablespoon: 1, g: 2, piece: 3, individual: 4 }
 

--- a/app/models/tea_review.rb
+++ b/app/models/tea_review.rb
@@ -18,6 +18,14 @@ class TeaReview < ApplicationRecord
     "華やかさ" => :flowery
   }.freeze
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name brand rating created_at]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[herbs user]
+  end
+
   before_validation :normalize_zero_flavors, :compact_custom_herb_names
 
   validates :brand, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
 end

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -1,0 +1,14 @@
+<%# app/views/bookmarks/_search_form.html.erb %>
+<%= render "shared/search_form",
+      q: q, url: bookmarks_path(tab: active_tab), clear_url: bookmarks_path(tab: active_tab),
+      text_fields: [
+        { attr: :title_cont,     placeholder: "レシピ名" },
+        { attr: :user_name_cont, placeholder: "ユーザー名" }
+      ],
+      blocks: [
+        { type: "functional" },
+        { type: "flavor" },
+        { type: "herb" },
+        { type: "caution_exclude" },
+        { type: "rating", locals: { param_prefix: "drinking_log_rating", id_prefix: "bm" } }
+      ] %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -4,10 +4,17 @@
   <div class="max-w-lg w-full bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5 my-5">
 
     <%# タイトル %>
-    <div class="flex justify-center mb-4">
-      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
-        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">保存したレシピ</h2>
+    <div data-controller="search-toggle" class="relative">
+      <div class="relative flex justify-center items-center mb-2">
+        <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+          <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">保存したレシピ</h2>
+        </div>
+        <div class="absolute right-0">
+          <%= render 'shared/search_button' %>
+        </div>
       </div>
+      <%= render 'bookmarks/search_form', q: @q, active_tab: @active_tab %>
+      <%= render 'shared/active_filters', q_params: params[:q], labels: {} %>
     </div>
 
     <%# タブ %>
@@ -66,7 +73,13 @@
       <% end %>
 
     <% else %>
-      <p class="text-herb-green-300 text-sm text-center py-8">保存したレシピはまだありません</p>
+      <p class="text-herb-green-300 text-sm text-center py-8">
+        <% if search_active? %>
+          該当するレシピが見つかりませんでした
+        <% else %>
+          保存したレシピはまだありません
+        <% end %>
+      </p>
     <% end %>
 
   </div>

--- a/app/views/herbs/_search_form.html.erb
+++ b/app/views/herbs/_search_form.html.erb
@@ -1,0 +1,11 @@
+<%# app/views/herbs/_search_form.html.erb %>
+<%= render "shared/search_form",
+      q: q, url: herbs_path, clear_url: herbs_path,
+      text_fields: [
+        { attr: :name_cont, placeholder: "ハーブ名" }
+      ],
+      blocks: [
+        { type: "functional" },
+        { type: "flavor" },
+        { type: "caution_exclude" }
+      ] %>

--- a/app/views/herbs/index.html.erb
+++ b/app/views/herbs/index.html.erb
@@ -1,16 +1,27 @@
 <div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-3 space-y-3 w-full">
 
   <div class="max-w-lg bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5">
-    <div class="flex justify-center">
-      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
-        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">ハーブ図鑑</h2>
+    <div data-controller="search-toggle" class="relative">
+      <div class="relative flex justify-center items-center mb-2">
+        <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+          <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">ハーブ図鑑</h2>
+        </div>
+        <div class="absolute right-0">
+          <%= render 'shared/search_button' %>
+        </div>
       </div>
+      <%= render 'herbs/search_form', q: @q %>
+      <%= render 'shared/active_filters', q_params: params[:q], labels: { "name_cont" => "ハーブ名" } %>
     </div>
 
     <%# ハーブが1件もない場合 %>
     <% if @herbs.empty? %>
       <div class="text-center py-20 text-herb-green-700/50">
-        <p>まだハーブが登録されていません</p>
+        <% if search_active? %>
+          <p>該当するハーブが見つかりませんでした</p>
+        <% else %>
+          <p>まだハーブが登録されていません</p>
+        <% end %>
       </div>
 
     <%# ハーブ一覧 %>

--- a/app/views/recipes/_search_form.html.erb
+++ b/app/views/recipes/_search_form.html.erb
@@ -1,0 +1,14 @@
+<%# app/views/recipes/_search_form.html.erb %>
+<%= render "shared/search_form",
+      q: q, url: recipes_path, clear_url: recipes_path,
+      text_fields: [
+        { attr: :title_cont,     placeholder: "レシピ名" },
+        { attr: :user_name_cont, placeholder: "ユーザー名" }
+      ],
+      blocks: [
+        { type: "functional" },
+        { type: "flavor" },
+        { type: "herb" },
+        { type: "caution_exclude" },
+        { type: "rating", locals: { param_prefix: "drinking_log_rating", id_prefix: "rec" } }
+      ] %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -2,70 +2,70 @@
 
   <div class="max-w-lg w-full bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5 my-5">
 
-    <%# タイトル %>
-    <div class="flex justify-center mb-6">
-      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
-        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">みんなのブレンド</h2>
+    <%# タイトル + 検索トグル %>
+    <div data-controller="search-toggle" class="relative">
+      <div class="relative flex justify-center items-center mb-2">
+        <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+          <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">ブレンド一覧</h2>
+        </div>
+        <div class="absolute right-0">
+          <%= render 'shared/search_button' %>
+        </div>
       </div>
+      <%= render 'recipes/search_form', q: @q %>
+      <%= render 'shared/active_filters', q_params: params[:q], labels: {} %>
     </div>
 
     <% if @recipes.any? %>
       <div class="w-full space-y-3 px-4 mt-4">
         <% @recipes.each do |recipe| %>
-          <%= link_to recipe_path(recipe), class: "block" do %>
-            <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
-              <div class="flex justify-between items-start mb-2">
-                <div class="flex items-center gap-2 min-w-0">
-                  <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
-                </div>
+          <% bookmark = @user_bookmarks.find { |b| b.recipe_id == recipe.id } %>
+          <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+            <div class="flex justify-between items-start mb-2">
+              <%= link_to recipe_path(recipe), class: "flex items-center gap-2 min-w-0 flex-1" do %>
+                <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
+              <% end %>
+              <div class="flex items-center gap-2 flex-shrink-0">
                 <% if recipe.drinking_log %>
-                  <div class="rate-star">
-                    ★ <%= recipe.drinking_log.rating %> / 5
-                  </div>
+                  <div class="rate-star">★ <%= recipe.drinking_log.rating %> / 5</div>
+                <% end %>
+                <%# 他人のレシピにのみブックマークボタンを表示 %>
+                <% if user_signed_in? && recipe.user != current_user %>
+                  <%= render 'bookmarks/button', recipe: recipe, bookmark: bookmark %>
                 <% end %>
               </div>
-
-    <% @public_recipes.each do |recipe| %>
-      <% bookmark = @user_bookmarks.find { |b| b.recipe_id == recipe.id } %>
-      <%# キャッシュキーにブックマーク状態を含める %>
-      <% cache [recipe, recipe.drinking_log, current_user.id, bookmark&.id] do %>
-        <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
-          <div class="flex justify-between items-start mb-2">
-            <%= link_to recipe_path(recipe), class: "flex items-center gap-2 min-w-0 flex-1" do %>
-              <h2 class="text-base font-medium text-herb-green-700 truncate"><%= recipe.title %></h2>
-            <% end %>
-            <div class="flex items-center gap-2 flex-shrink-0">
-              <% if recipe.drinking_log %>
-                <div class="rate-star">★ <%= recipe.drinking_log.rating %> / 5</div>
-              <% end %>
-              <%# 他人のレシピにのみブックマークボタンを表示 %>
-              <% if recipe.user != current_user %>
-                <%= render 'bookmarks/button', recipe: recipe, bookmark: bookmark %>
-              <% end %>
             </div>
-          </div>
 
-          <%= link_to recipe_path(recipe) do %>
-            <div class="flex flex-wrap gap-1 mb-3">
-              <% recipe.recipe_herbs.each do |rh| %>
-                <% if rh.herb %>
-                  <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
-                <% elsif rh.custom_herb_name.present? %>
-                  <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+            <%= link_to recipe_path(recipe) do %>
+              <div class="flex flex-wrap gap-1 mb-3">
+                <% recipe.recipe_herbs.each do |rh| %>
+                  <% if rh.herb %>
+                    <span class="tag-herb text-[10px]"><%= rh.herb.name %></span>
+                  <% elsif rh.custom_herb_name.present? %>
+                    <span class="tag-herb text-[10px]"><%= rh.custom_herb_name %></span>
+                  <% end %>
                 <% end %>
-              <% end %>
-            </div>
-            <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
-              <span>by <%= recipe.user.name %></span>
-              <% if recipe.user_id == current_user.id %>
-                <span class="my-blend-tag">自分</span>
-              <% end %>
-              <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+              </div>
+              <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
+                <span>by <%= recipe.user.name %></span>
+                <% if user_signed_in? && recipe.user_id == current_user.id %>
+                  <span class="my-blend-tag">自分</span>
+                <% end %>
+                <span class="ml-auto"><%= l recipe.created_at, format: :short %></span>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
+      <%= paginate @recipes %>
+
+    <% else %>
+      <p class="text-herb-green-300 text-sm text-center py-8">
+        該当するブレンドが見つかりませんでした
+      </p>
     <% end %>
+
   </div>
 
   <%= render 'shared/footer' %>

--- a/app/views/shared/_active_filters.html.erb
+++ b/app/views/shared/_active_filters.html.erb
@@ -1,0 +1,134 @@
+<%# locals: (q_params:, labels:) %>
+<%
+  label_map = {
+    "title_cont"                    => "レシピ名",
+    "recipe_herbs_herb_name_cont"   => "ハーブ名",
+    "user_name_cont"                => "ユーザー名",
+    "drinking_log_rating_in"        => "評価",
+    "drinking_log_rating_gteq"      => "評価(最低)",
+    "drinking_log_rating_lteq"      => "評価(最高)",
+    "name_cont"                     => labels&.fetch("name_cont", "名前"),
+    "brand_cont"                    => "ブランド名",
+    "herbs_name_cont"               => "ハーブ名",
+    "rating_in"                     => "評価",
+    "rating_gteq"                   => "評価(最低)",
+    "rating_lteq"                   => "評価(最高)",
+    "caution_tags_name_cont"        => "禁忌",
+  }
+
+  q_hash = q_params.respond_to?(:to_unsafe_h) ? q_params.to_unsafe_h : q_params.to_h
+  q_hash = q_hash.reject do |k, v|
+    val = Array(v).first.to_s
+    (k.end_with?("_gteq") && val == "1") || (k.end_with?("_lteq") && val == "5")
+  end
+  active_filters = q_hash.select { |_k, v| Array(v).any?(&:present?) }
+
+  # herb_names[] は q の外にある独立パラメーター
+  herb_names_active = Array(params[:herb_names]).select(&:present?)
+
+  # flavor_names[] も q の外にある独立パラメーター
+  flavor_names_active = Array(params[:flavor_names]).select(&:present?)
+
+  # exclude_caution_tags[] も q の外にある独立パラメーター
+  excluded_tags_active = Array(params[:exclude_caution_tags]).select(&:present?)
+
+  # functional_categories[] / functional_names[] も q の外にある独立パラメーター（ペアで AND 検索）
+  functional_pairs_active = Array(params[:functional_categories]).zip(Array(params[:functional_names]))
+                                                                  .reject { |c, n| c.blank? && n.blank? }
+
+  has_any = active_filters.any? || herb_names_active.any? || flavor_names_active.any? ||
+            excluded_tags_active.any? || functional_pairs_active.any?
+%>
+
+<% if has_any %>
+  <div class="flex flex-wrap items-center gap-1 px-1 mt-3">
+
+    <%# q[] 由来のフィルター %>
+    <% active_filters.each do |key, value| %>
+      <%
+        label       = label_map[key] || key
+        values      = Array(value).select(&:present?)
+        display_val = if key.end_with?("_in")
+          values.map { |v| "★#{v}" }.join(" / ")
+        elsif key.end_with?("_gteq") || key.end_with?("_lteq")
+          "★#{values.first}"
+        else
+          values.first
+        end
+        new_q       = active_filters.except(key).presence
+        remove_url  = url_for(request.query_parameters.merge("q" => new_q).except("page", "my_page"))
+      %>
+      <span class="inline-flex items-center gap-1 bg-herb-green-100 text-herb-green-700 text-[11px] px-2 py-0.5 rounded-full border border-herb-green-300">
+        <span><%= label %>: <%= display_val %></span>
+        <%= link_to remove_url,
+              class: "text-herb-green-500 hover:text-herb-green-800 leading-none font-bold ml-0.5",
+              title: "この条件を外す" do %>✕<% end %>
+      </span>
+    <% end %>
+
+    <%# herb_names[] 由来のフィルター（1件ずつタグ表示） %>
+    <% herb_names_active.each do |herb_name| %>
+      <%
+        remaining  = herb_names_active.reject { |n| n == herb_name }
+        remove_url = url_for(request.query_parameters.merge("herb_names" => remaining.presence).except("page", "my_page"))
+      %>
+      <span class="inline-flex items-center gap-1 bg-herb-green-100 text-herb-green-700 text-[11px] px-2 py-0.5 rounded-full border border-herb-green-300">
+        <span>ハーブ: <%= herb_name %></span>
+        <%= link_to remove_url,
+              class: "text-herb-green-500 hover:text-herb-green-800 leading-none font-bold ml-0.5",
+              title: "この条件を外す" do %>✕<% end %>
+      </span>
+    <% end %>
+
+    <%# flavor_names[] 由来のフィルター（1件ずつタグ表示） %>
+    <% flavor_names_active.each do |flavor_name| %>
+      <%
+        remaining  = flavor_names_active.reject { |n| n == flavor_name }
+        remove_url = url_for(request.query_parameters.merge("flavor_names" => remaining.presence).except("page", "my_page"))
+      %>
+      <span class="inline-flex items-center gap-1 bg-herb-green-100 text-herb-green-700 text-[11px] px-2 py-0.5 rounded-full border border-herb-green-300">
+        <span>風味: <%= flavor_name %></span>
+        <%= link_to remove_url,
+              class: "text-herb-green-500 hover:text-herb-green-800 leading-none font-bold ml-0.5",
+              title: "この条件を外す" do %>✕<% end %>
+      </span>
+    <% end %>
+
+    <%# functional_categories[] / functional_names[] 由来のフィルター（ペアごとに1件ずつ表示） %>
+    <% functional_pairs_active.each do |category, name| %>
+      <%
+        remaining = functional_pairs_active.reject { |c, n| c == category && n == name }
+        remove_url = url_for(request.query_parameters.merge(
+          "functional_categories" => remaining.map(&:first).presence,
+          "functional_names"      => remaining.map(&:last).presence
+        ).except("page", "my_page"))
+        label_text = name.presence ? "効能: #{name}" : "効能分類: #{category}"
+      %>
+      <span class="inline-flex items-center gap-1 bg-herb-green-100 text-herb-green-700 text-[11px] px-2 py-0.5 rounded-full border border-herb-green-300">
+        <span><%= label_text %></span>
+        <%= link_to remove_url,
+              class: "text-herb-green-500 hover:text-herb-green-800 leading-none font-bold ml-0.5",
+              title: "この条件を外す" do %>✕<% end %>
+      </span>
+    <% end %>
+
+    <%# exclude_caution_tags[] 由来のフィルター（1件ずつタグ表示） %>
+    <% excluded_tags_active.each do |tag_name| %>
+      <%
+        remaining  = excluded_tags_active.reject { |n| n == tag_name }
+        remove_url = url_for(request.query_parameters.merge("exclude_caution_tags" => remaining.presence).except("page", "my_page"))
+      %>
+      <span class="inline-flex items-center gap-1 bg-herb-green-100 text-herb-green-700 text-[11px] px-2 py-0.5 rounded-full border border-herb-green-300">
+        <span>禁忌除外: <%= tag_name %></span>
+        <%= link_to remove_url,
+              class: "text-herb-green-500 hover:text-herb-green-800 leading-none font-bold ml-0.5",
+              title: "この条件を外す" do %>✕<% end %>
+      </span>
+    <% end %>
+
+    <%= link_to url_for(request.query_parameters.except("q", "herb_names", "flavor_names", "exclude_caution_tags", "functional_categories", "functional_names", "page", "my_page")),
+          class: "text-[11px] text-herb-green-500 underline hover:text-herb-green-700 ml-1" do %>
+      すべてクリア
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/shared/_caution_tag_field.html.erb
+++ b/app/views/shared/_caution_tag_field.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (name: "") %>
+<div class="tag-field flex gap-1">
+  <select name="exclude_caution_tags[]"
+          class="flex-1 rounded-xl border border-herb-green-200 bg-herb-green-50 px-3 py-2 text-sm text-herb-green-800 focus:outline-none focus:ring-2 focus:ring-herb-green-400">
+    <option value="">選択しない</option>
+    <% CautionTag.order(:name).each do |tag| %>
+      <option value="<%= tag.name %>" <%= "selected" if tag.name == name %>><%= tag.name %></option>
+    <% end %>
+  </select>
+  <button type="button"
+          data-action="tag-field#removeField"
+          class="text-herb-green-400 hover:text-herb-green-700 px-2 text-lg leading-none flex-shrink-0">✕</button>
+</div>

--- a/app/views/shared/_functional_field.html.erb
+++ b/app/views/shared/_functional_field.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (category: "", name: "") %>
+<div class="tag-field flex gap-2"
+     data-controller="functional-category"
+     data-functional-category-categories-value="<%= FunctionalTag::CATEGORIES.to_json %>">
+  <select name="functional_categories[]"
+          data-functional-category-target="category"
+          data-action="functional-category#change"
+          class="flex-1 rounded-xl border border-herb-green-200 bg-herb-green-50 px-3 py-2 text-sm text-herb-green-800 focus:outline-none focus:ring-2 focus:ring-herb-green-400">
+    <option value="">分類を選択</option>
+    <% FunctionalTag::CATEGORIES.each_key do |c| %>
+      <option value="<%= c %>" <%= "selected" if c == category %>><%= c %></option>
+    <% end %>
+  </select>
+  <select name="functional_names[]"
+          data-functional-category-target="name"
+          class="flex-1 rounded-xl border border-herb-green-200 bg-herb-green-50 px-3 py-2 text-sm text-herb-green-800 focus:outline-none focus:ring-2 focus:ring-herb-green-400">
+    <option value="">指定なし（分類全体）</option>
+    <% (FunctionalTag::CATEGORIES[category] || []).each do |n| %>
+      <option value="<%= n %>" <%= "selected" if n == name %>><%= n %></option>
+    <% end %>
+  </select>
+  <button type="button"
+          data-action="tag-field#removeField"
+          class="text-herb-green-400 hover:text-herb-green-700 px-2 text-lg leading-none flex-shrink-0">✕</button>
+</div>

--- a/app/views/shared/_herb_field.html.erb
+++ b/app/views/shared/_herb_field.html.erb
@@ -1,0 +1,24 @@
+<%# locals: (name: "") %>
+<div class="herb-field relative flex gap-1">
+  <%# 入力欄ラッパー（▼ボタンを右内側に配置） %>
+  <div class="relative flex-1">
+    <input type="text"
+           name="herb_names[]"
+           value="<%= name %>"
+           placeholder="ハーブ名を入力"
+           autocomplete="off"
+           data-action="input->herb-search#suggest blur->herb-search#blur"
+           class="w-full rounded-xl border border-herb-green-200 bg-herb-green-50 pl-3 pr-8 py-2 text-sm text-herb-green-800 placeholder-herb-green-400 focus:outline-none focus:ring-2 focus:ring-herb-green-400">
+    <%# ▼ ドロップダウンボタン（ネイティブ select のシェブロンに合わせる） %>
+    <button type="button"
+            data-action="mousedown->herb-search#showAll"
+            class="absolute right-3 top-1/2 -translate-y-1/2 text-herb-green-800 text-[10px] leading-none pointer-events-auto"
+            title="一覧から選ぶ">▼</button>
+    <%# 候補リスト %>
+    <ul class="herb-suggestions hidden absolute left-0 top-full z-50 w-full bg-herb-green-600 border border-herb-green-700 rounded-xl shadow-lg mt-0.5 overflow-hidden max-h-48 overflow-y-auto"></ul>
+  </div>
+  <%# ✕ 削除ボタン %>
+  <button type="button"
+          data-action="herb-search#removeField"
+          class="text-herb-green-400 hover:text-herb-green-700 px-2 text-lg leading-none flex-shrink-0">✕</button>
+</div>

--- a/app/views/shared/_search_button.html.erb
+++ b/app/views/shared/_search_button.html.erb
@@ -1,0 +1,9 @@
+<%# locals: () %>
+<button type="button"
+        data-action="search-toggle#toggle"
+        class="w-9 h-9 rounded-full bg-herb-green-600 hover:bg-herb-green-600/70 active:scale-95 flex items-center justify-center shadow-sm transition"
+        title="検索">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="white" class="w-5 h-5">
+    <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+  </svg>
+</button>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (q:, url:, clear_url:, text_fields: [], blocks: []) %>
+<div data-search-toggle-target="form"
+     class="hidden absolute left-0 right-0 top-full z-30 mt-2 p-4 bg-white rounded-2xl border border-herb-green-200 shadow-lg">
+  <%= search_form_for q, url: url, html: { class: "space-y-3" } do |f| %>
+    <% if text_fields.any? %>
+      <div class="grid grid-cols-2 gap-2">
+        <% text_fields.each do |tf| %>
+          <%= f.search_field tf[:attr], placeholder: tf[:placeholder],
+                class: "w-full rounded-xl border border-herb-green-200 bg-herb-green-50 px-3 py-2 text-sm text-herb-green-800 placeholder-herb-green-400 focus:outline-none focus:ring-2 focus:ring-herb-green-400" %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% blocks.each do |block| %>
+      <%= render "shared/search_blocks/#{block[:type]}", **(block[:locals] || {}) %>
+    <% end %>
+
+    <div class="flex gap-2 justify-end">
+      <%= link_to "クリア", clear_url,
+            class: "bg-herb-white text-herb-green-600 hover:bg-herb-green-600/30 hover:text-white text-sm font-medium px-3 py-2 rounded-xl transition cursor-pointer border border-herb-green-300" %>
+      <%= f.submit "検索",
+            class: "bg-herb-green-600 hover:bg-herb-green-600/70 text-white text-sm font-medium px-5 py-2 rounded-xl transition cursor-pointer" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_star_range_field.html.erb
+++ b/app/views/shared/_star_range_field.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (name:, id_prefix:, current:, default:) %>
+<% selected = current.presence&.to_i || default %>
+<div class="flex flex-row-reverse gap-0.5">
+  <% [5, 4, 3, 2, 1].each do |v| %>
+    <% id = "#{id_prefix}_#{v}" %>
+    <%= radio_button_tag name, v, selected == v, id: id, class: "peer sr-only" %>
+    <%= label_tag id, "★", class: "cursor-pointer text-3xl text-gray-300 peer-checked:text-herb-green-600" %>
+  <% end %>
+</div>

--- a/app/views/shared/search_blocks/_caution_exclude.html.erb
+++ b/app/views/shared/search_blocks/_caution_exclude.html.erb
@@ -1,0 +1,22 @@
+<%# locals: () %>
+<%# 禁忌タグ除外検索 %>
+<div data-controller="tag-field">
+  <p class="text-xs text-herb-green-700/80 mb-1">禁忌タグを除外（複数指定で除外）</p>
+
+  <div data-tag-field-target="fieldList" class="space-y-1">
+    <% excluded_tags = Array(params[:exclude_caution_tags]).reject(&:blank?).presence || [""] %>
+    <% excluded_tags.each do |name| %>
+      <%= render 'shared/caution_tag_field', name: name %>
+    <% end %>
+  </div>
+
+  <template data-tag-field-target="template">
+    <%= render 'shared/caution_tag_field', name: "" %>
+  </template>
+
+  <button type="button"
+          data-action="tag-field#addField"
+          class="mt-1 text-xs text-herb-green-600 hover:text-herb-green-800 transition">
+    ＋ 除外タグを追加
+  </button>
+</div>

--- a/app/views/shared/search_blocks/_flavor.html.erb
+++ b/app/views/shared/search_blocks/_flavor.html.erb
@@ -1,0 +1,18 @@
+<%# locals: () %>
+<%# 風味（最大2つ AND 検索） %>
+<div data-controller="checkbox-limit" data-checkbox-limit-max-value="2">
+  <p class="text-xs text-herb-green-700/80 mb-1">風味（2つ選択・AND 検索）</p>
+  <div class="flex gap-1 flex-wrap">
+    <% selected_flavors = Array(params[:flavor_names]).reject(&:blank?) %>
+    <% FlavorTag.order(:name).each do |tag| %>
+      <label class="cursor-pointer px-3 py-1 rounded-full text-sm border transition
+                    bg-white text-herb-green-700/80 border-herb-green-300
+                    hover:bg-herb-green-50
+                    has-[:checked]:bg-herb-green-600 has-[:checked]:text-white has-[:checked]:border-herb-green-600">
+        <%= check_box_tag "flavor_names[]", tag.name, selected_flavors.include?(tag.name),
+              class: "sr-only", data: { action: "checkbox-limit#limit" } %>
+        <%= tag.name %>
+      </label>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/search_blocks/_functional.html.erb
+++ b/app/views/shared/search_blocks/_functional.html.erb
@@ -1,0 +1,24 @@
+<%# locals: () %>
+<%# 効能（分類 → 個別タグ、複数指定で AND 検索） %>
+<div data-controller="tag-field">
+  <p class="text-xs text-herb-green-700/80 mb-1">効能（複数指定で AND 検索）</p>
+
+  <div data-tag-field-target="fieldList" class="space-y-1">
+    <% categories = Array(params[:functional_categories]) %>
+    <% names      = Array(params[:functional_names]) %>
+    <% pairs = categories.zip(names).reject { |c, n| c.blank? && n.blank? }.presence || [[nil, nil]] %>
+    <% pairs.each do |category, name| %>
+      <%= render 'shared/functional_field', category: category, name: name %>
+    <% end %>
+  </div>
+
+  <template data-tag-field-target="template">
+    <%= render 'shared/functional_field', category: nil, name: nil %>
+  </template>
+
+  <button type="button"
+          data-action="tag-field#addField"
+          class="mt-1 text-xs text-herb-green-600 hover:text-herb-green-800 transition">
+    ＋ 効能を追加
+  </button>
+</div>

--- a/app/views/shared/search_blocks/_herb.html.erb
+++ b/app/views/shared/search_blocks/_herb.html.erb
@@ -1,0 +1,22 @@
+<%# locals: () %>
+<%# ハーブ複数検索 %>
+<div data-controller="herb-search" data-action="keydown->herb-search#keydown">
+  <p class="text-xs text-herb-green-700/80 mb-1">ハーブ（複数指定で AND 検索）</p>
+
+  <div data-herb-search-target="fieldList" class="space-y-1">
+    <% herb_names = Array(params[:herb_names]).reject(&:blank?).presence || [""] %>
+    <% herb_names.each do |name| %>
+      <%= render 'shared/herb_field', name: name %>
+    <% end %>
+  </div>
+
+  <template data-herb-search-target="template">
+    <%= render 'shared/herb_field', name: "" %>
+  </template>
+
+  <button type="button"
+          data-action="herb-search#addField"
+          class="mt-1 text-xs text-herb-green-600 hover:text-herb-green-800 transition">
+    ＋ ハーブを追加
+  </button>
+</div>

--- a/app/views/shared/search_blocks/_rating.html.erb
+++ b/app/views/shared/search_blocks/_rating.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (param_prefix:, id_prefix:) %>
+<%# 評価レンジ（最低〜最高） %>
+<div>
+  <p class="text-xs text-herb-green-600 mb-1">評価</p>
+  <div class="flex items-end gap-2">
+    <div class="flex flex-col items-center">
+      <span class="text-[11px] text-herb-green-500 mb-0.5">Min.</span>
+      <%= render 'shared/star_range_field',
+            name: "q[#{param_prefix}_gteq]", id_prefix: "#{id_prefix}_min",
+            current: params.dig(:q, :"#{param_prefix}_gteq"), default: 1 %>
+    </div>
+    <span class="text-herb-green-500 pb-1">〜</span>
+    <div class="flex flex-col items-center">
+      <span class="text-[11px] text-herb-green-500 mb-0.5">Max</span>
+      <%= render 'shared/star_range_field',
+            name: "q[#{param_prefix}_lteq]", id_prefix: "#{id_prefix}_max",
+            current: params.dig(:q, :"#{param_prefix}_lteq"), default: 5 %>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,11 +2,18 @@
 
   <div class="max-w-lg w-full bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5">
 
-    <%# タイトル %>
-    <div class="flex justify-center">
-      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
-        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">ブレンド一覧</h2>
+    <%# タイトル + 検索トグル %>
+    <div data-controller="search-toggle" class="relative">
+      <div class="relative flex justify-center items-center mb-2">
+        <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+          <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">ブレンド一覧</h2>
+        </div>
+        <div class="absolute right-0">
+          <%= render 'shared/search_button' %>
+        </div>
       </div>
+      <%= render 'recipes/search_form', q: @q %>
+      <%= render 'shared/active_filters', q_params: params[:q], labels: {} %>
     </div>
 
     <div class="herb-tab-group mt-4">

--- a/app/views/tea_reviews/_search_form.html.erb
+++ b/app/views/tea_reviews/_search_form.html.erb
@@ -1,0 +1,14 @@
+<%# app/views/tea_reviews/_search_form.html.erb %>
+<%= render "shared/search_form",
+      q: q, url: tea_reviews_path, clear_url: tea_reviews_path,
+      text_fields: [
+        { attr: :name_cont,  placeholder: "商品名" },
+        { attr: :brand_cont, placeholder: "ブランド名" }
+      ],
+      blocks: [
+        { type: "functional" },
+        { type: "flavor" },
+        { type: "herb" },
+        { type: "caution_exclude" },
+        { type: "rating", locals: { param_prefix: "rating", id_prefix: "tr" } }
+      ] %>

--- a/app/views/tea_reviews/index.html.erb
+++ b/app/views/tea_reviews/index.html.erb
@@ -1,52 +1,58 @@
 <div class="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-3 space-y-3 w-full">
 
   <div class="max-w-lg w-full bg-white rounded-2xl shadow-sm border border-herb-green-100 p-4 md:p-5">
-    <div class="flex justify-center">
-      <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
-        <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">既製品レビュー</h2>
+
+    <%# タイトル + 検索トグル %>
+    <div data-controller="search-toggle" class="relative">
+      <div class="relative flex justify-center items-center mb-2">
+        <div class="bg-herb-green-100 px-8 py-2 rounded-full shadow-sm border border-herb-green-600/20">
+          <h2 class="text-2xl text-herb-green-700 font-medium tracking-wide">既製品レビュー</h2>
+        </div>
+        <div class="absolute right-0">
+          <%= render 'shared/search_button' %>
+        </div>
       </div>
+      <%= render 'tea_reviews/search_form', q: @q %>
+      <%= render 'shared/active_filters', q_params: params[:q], labels: { "name_cont" => "商品名" } %>
     </div>
 
-
-<% if @tea_reviews.any? %>
+    <% if @tea_reviews.any? %>
       <div class="w-full space-y-3 px-4 mt-4">
         <% @tea_reviews.each do |review| %>
-        <%= link_to tea_review_path(review), class: "block" do %>
-          <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
-          <div class="flex items-start justify-between">
-            <div>
-              <p class="text-xs text-herb-green-700/80"><%= review.brand %></p>
-              <p class="text-base font-bold text-herb-green-800"><%= review.name %></p>
-            </div>
-            <div class="rate-star">
-              ★ <%= review.rating %> / 5
-            </div>
-          </div>
+          <%= link_to tea_review_path(review), class: "block" do %>
+            <div class="bg-herb-green-50/50 rounded-2xl p-5 border border-herb-green-100 shadow-sm hover:opacity-80 transition">
+              <div class="flex items-start justify-between">
+                <div>
+                  <p class="text-xs text-herb-green-700/80"><%= review.brand %></p>
+                  <p class="text-base font-bold text-herb-green-800"><%= review.name %></p>
+                </div>
+                <div class="rate-star">
+                  ★ <%= review.rating %> / 5
+                </div>
+              </div>
 
               <% if review.herbs.any? %>
                 <div class="mt-2 flex flex-wrap gap-1 mb-3">
                   <% review.herbs.each do |herb| %>
-                    <span class="tag-herb text-[10px]">
-                      <%= herb.name %>
-                    </span>
+                    <span class="tag-herb text-[10px]"><%= herb.name %></span>
                   <% end %>
                 </div>
               <% end %>
+
               <div class="flex gap-2 items-center text-[10px] text-herb-green-700/80">
                 <span>by <%= review.user.name %></span>
-                <% if review.user_id == current_user.id %>
-                  <span class="my-blend-tag">自分</span>
-                <% end %>
                 <span class="ml-auto"><%= l review.created_at, format: :short %></span>
               </div>
-          </div>
-        <% end %>
+            </div>
+          <% end %>
         <% end %>
       </div>
       <%= paginate @tea_reviews %>
-      <% else %>
-        <p class="text-herb-green-300 text-sm text-center py-4">レビューがまだありません<br>最初のレビューを登録しましょう</p>
-      <% end %>
+    <% else %>
+      <p class="text-herb-green-300 text-sm text-center py-4">
+        該当するレビューが見つかりませんでした
+      </p>
+    <% end %>
 
     <%= content_for :fixed_button do %>
       <%= link_to new_tea_review_path,
@@ -60,6 +66,7 @@
         <span class="fab-text">既製ブレンドを登録する</span>
       <% end %>
     <% end %>
+
   </div>
 
 </div>

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,3 @@
+Ransack.configure do |config|
+  config.sanitize_custom_scope_booleans = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
   # ログイン済みなら Controller 側で home へリダイレクトさせます。
   root 'static_pages#top'
 
-  resources :herbs, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+  resources :herbs, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
+    collection do
+      get :autocomplete
+    end
+  end
   resources :tea_reviews, only: [:index, :new, :create, :show, :edit, :update, :destroy]
   resources :recipes do
     resources :drinking_logs, only: [:new, :create, :show, :edit, :update]


### PR DESCRIPTION
## 概要

ブレンド（recipes）・ブックマーク・ハーブ図鑑・ティーレビュー・ホームの各一覧に、
リッチな絞り込み検索機能を追加しました。Ransack をベースに、ハーブ AND 検索・
風味・効能（分類2段）・禁忌タグ除外・評価レンジを組み合わせて検索できます。

## 背景

これまで一覧画面には検索手段がなく、登録数が増えると目的のブレンド／ハーブに
辿り着きにくい状態でした。配合ハーブや効能・風味から絞り込めるようにすることで、
ブレンドの発見性を高めます。

## 変更内容

- **検索フォームの共通コンポーネント化**
  - 設定駆動の `shared/_search_form.html.erb`（外枠）＋ `shared/search_blocks/*`（部品）を新設
  - 各リソースは「テキスト欄リスト」「ブロックリスト」を渡す薄いラッパーに統一
  - 虫眼鏡クリックでフロート表示、カード外クリック／Esc で閉じる
- **絞り込みロジック（`ApplicationController` に集約）**
  - タグ（風味・効能・禁忌）は配合ハーブ経由（`herbs` join）で辿るよう実装
  - `model:` / `tag_join:` をパラメータ化し、recipes/tea_reviews/herbs で再利用
  - `apply_herb_based_filters`（配合経由）/ `apply_herb_self_filters`（ハーブ直結）の2系統
- **各検索 UI**
  - ハーブ: 入力補完つき複数指定の AND 検索
  - 風味: 最大2つチップ選択の AND 検索
  - 効能: 分類→個別タグの2段プルダウン、＋ボタンで複数 AND
  - 禁忌: タグ除外検索（複数指定）
  - 評価: ★ Min.〜Max のレンジ選択（CSS のみ）
- **空状態対応**
  - `search_active?` ヘルパーで該当0件時に「見つかりませんでした」を表示

## 確認方法

1. recipes / home / bookmarks / tea_reviews / herbs の各一覧で虫眼鏡を開く
2. ハーブ・風味・効能・禁忌除外・評価レンジで検索し、結果件数が想定どおりか確認
3. 効能は「分類のみ選択」で分類内の全タグにマッチすることを確認
4. パンくず（適用中フィルタ）と「すべてクリア」の動作を確認
5. カード外クリック／Esc で検索カードが閉じることを確認

## 影響範囲

- 各一覧コントローラの `index`（既存表示は維持、絞り込みを追加適用）
- `ApplicationController` に検索用 protected メソッドを追加
- 各モデルに `ransackable_attributes` / `ransackable_associations` を追加
- ルーティングに `herbs#autocomplete` を追加

## スクリーンショット

**ブレンド一覧・検索カード
| 改善前 | 改善後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/a82bda0df2bd72356aacd3f2ffeebc95.png)](https://gyazo.com/a82bda0df2bd72356aacd3f2ffeebc95) | [![Image from Gyazo](https://i.gyazo.com/f3c8c796d47069879f794b24f71b8889.png)](https://gyazo.com/f3c8c796d47069879f794b24f71b8889)[![Image from Gyazo](https://i.gyazo.com/33b930b84ae02e0bead2d50a2e5373b6.png)](https://gyazo.com/33b930b84ae02e0bead2d50a2e5373b6) |

## 関連 issue

Closes #38 