### PR TITLE
カードからはみ出る欄をレスポンシブ対応化

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -109,7 +109,7 @@
 
   /* 全幅テキスト・日付・数値入力 */
   .form-input {
-    @apply w-full border border-herb-green-300 rounded-xl px-4 py-2 text-sm
+    @apply min-w-0 max-w-full w-full border border-herb-green-300 rounded-xl px-4 py-2 text-sm
            focus:outline-none focus:ring-2 focus:ring-herb-green-400;
   }
 
@@ -117,6 +117,15 @@
   .form-textarea {
     @apply w-full border border-herb-green-300 rounded-xl px-4 py-2 text-sm
            focus:outline-none focus:ring-2 focus:ring-herb-green-400 resize-none;
+  }
+  /* iOS Safari の date/time input がカード幅を超えるのを防ぐ */
+  input[type="date"],
+  input[type="time"],
+  input[type="datetime-local"] {
+    -webkit-appearance: none;
+    appearance: none;
+    min-width: 0;
+    max-width: 100%;
   }
 
   /* ハーブ配合行: ハーブ選択・カスタム名入力（flex-1） */

--- a/app/views/drinking_logs/edit.html.erb
+++ b/app/views/drinking_logs/edit.html.erb
@@ -20,50 +20,8 @@
 
     <%= form_with model: [@recipe, @drinking_log], class: "space-y-6" do |f| %>
 
-      <%# 総合評価 %>
-      <div class="flex flex-col items-center">
-        <%= f.label :rating, "総合評価（5段階）", class: "block text-sm font-medium text-herb-green-700 mb-2" %>
-        <div class="flex gap-4">
-          <% (1..5).each do |n| %>
-            <label class="flex flex-col items-center gap-1 cursor-pointer group">
-              <%= f.radio_button :rating, n, class: "sr-only peer", required: true %>
-              <div class="w-10 h-10 flex items-center justify-center rounded-full border border-herb-green-200
-                          peer-checked:bg-herb-green-600 peer-checked:text-white peer-checked:border-herb-green-600
-                          group-hover:border-herb-green-400 transition-all">
-                <%= n %>
-              </div>
-            </label>
-          <% end %>
-        </div>
-      </div>
-
-      <%# 風味記録タイトル %>
-      <%= f.label :rating, "風味記録（任意）", class: "block text-sm font-medium text-herb-green-700 mb-2 flex flex-col items-center" %>
-      <%# 味のパラメータ（DBのタグから動的に生成） %>
-      <div class="grid grid-cols-2 gap-x-6 gap-y-4">
-        <% @flavor_tags.each do |tag| %>
-          <% column_name = DrinkingLog::FLAVOR_MAPPING[tag.name] %>
-          <% if column_name %>
-            <div data-controller="toggle-radio">
-              <%= f.label column_name, tag.name, class: "block text-xs font-medium text-herb-green-600 mb-2" %>
-              <div class="flex gap-1.5">
-                <% (1..5).each do |n| %>
-                  <label class="flex flex-col items-center gap-1 cursor-pointer group">
-                    <%= f.radio_button column_name, n,
-                          class: "sr-only peer",
-                          data: { "toggle-radio-target": "input", action: "click->toggle-radio#toggle", "was-checked": "false" } %>
-                    <div class="w-5 h-5 flex items-center justify-center rounded-full border border-herb-green-200
-                                peer-checked:bg-herb-green-600 peer-checked:text-white peer-checked:border-herb-green-600
-                                group-hover:border-herb-green-400 transition-all text-sm">
-                      <%= n %>
-                    </div>
-                  </label>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-      </div>
+      <%# 評価 %>
+      <%= render 'shared/rating_form', f: f, flavor_tags: @flavor_tags, flavor_mapping: DrinkingLog::FLAVOR_MAPPING %>
 
       <%# 自由な感想 %>
       <div>

--- a/app/views/shared/_rating_form.html.erb
+++ b/app/views/shared/_rating_form.html.erb
@@ -1,18 +1,13 @@
 <%# 総合評価 %>
 <div class="flex flex-col items-center">
   <%= f.label :rating, "総合評価（5段階）", class: "block text-sm font-medium text-herb-green-700 mb-2" %>
-  <div class="flex gap-4">
-    <% (1..5).each do |n| %>
-      <label class="flex flex-col items-center gap-1 cursor-pointer group">
-        <%= f.radio_button :rating, n, class: "sr-only peer", required: true %>
-        <div class="w-10 h-10 flex items-center justify-center rounded-full border border-herb-green-200
-                    peer-checked:bg-herb-green-600 peer-checked:text-white peer-checked:border-herb-green-600
-                    group-hover:border-herb-green-400 transition-all">
-          <%= n %>
-        </div>
-      </label>
-    <% end %>
-  </div>
+    <div class="flex flex-row-reverse justify-center gap-1">
+      <% [5, 4, 3, 2, 1].each do |n| %>
+        <%= f.radio_button :rating, n, class: "peer sr-only", required: true %>
+        <%= f.label :rating, "★", value: n,
+              class: "cursor-pointer text-4xl sm:text-5xl text-gray-300 peer-checked:text-herb-green-600 transition-colors" %>
+      <% end %>
+    </div>
 </div>
 
 <%# 風味記録 %>
@@ -23,13 +18,13 @@
     <% if column_name %>
       <div data-controller="toggle-radio">
         <%= f.label column_name, tag.name, class: "block text-xs font-medium text-herb-green-600 mb-2" %>
-        <div class="flex gap-1.5">
+        <div class="flex flex-wrap gap-1 min-w-0">
           <% (1..5).each do |n| %>
             <label class="flex flex-col items-center gap-1 cursor-pointer group">
               <%= f.radio_button column_name, n,
                     class: "sr-only peer",
                     data: { "toggle-radio-target": "input", action: "click->toggle-radio#toggle", "was-checked": "false" } %>
-              <div class="w-5 h-5 flex items-center justify-center rounded-full border border-herb-green-200
+              <div class="w-5 h-5 sm:w-8 sm:h-8 flex items-center justify-center rounded-full border border-herb-green-200
                           peer-checked:bg-herb-green-600 peer-checked:text-white peer-checked:border-herb-green-600
                           group-hover:border-herb-green-400 transition-all text-sm">
                 <%= n %>

--- a/app/views/shared/_star_range_field.html.erb
+++ b/app/views/shared/_star_range_field.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (name:, id_prefix:, current:, default:) %>
 <% selected = current.presence&.to_i || default %>
-<div class="flex flex-row-reverse gap-0.5">
+<div class="flex flex-row-reverse gap-0.5 min-w-0">
   <% [5, 4, 3, 2, 1].each do |v| %>
     <% id = "#{id_prefix}_#{v}" %>
     <%= radio_button_tag name, v, selected == v, id: id, class: "peer sr-only" %>

--- a/app/views/shared/search_blocks/_rating.html.erb
+++ b/app/views/shared/search_blocks/_rating.html.erb
@@ -2,7 +2,7 @@
 <%# 評価レンジ（最低〜最高） %>
 <div>
   <p class="text-xs text-herb-green-600 mb-1">評価</p>
-  <div class="flex items-end gap-2">
+  <div class="flex flex-wrap items-end justify-center gap-x-2 gap-y-1">
     <div class="flex flex-col items-center">
       <span class="text-[11px] text-herb-green-500 mb-0.5">Min.</span>
       <%= render 'shared/star_range_field',

--- a/app/views/tea_reviews/_form.html.erb
+++ b/app/views/tea_reviews/_form.html.erb
@@ -83,51 +83,8 @@
 <div class="space-y-4">
   <h3 class="text-sm font-semibold text-herb-green-700 border-b border-herb-green-200 pb-1">感想</h3>
 
-  <%# 総合評価 %>
-  <div class="flex flex-col items-center">
-    <%= f.label :rating, "総合評価（5段階）", class: "block text-sm font-medium text-herb-green-700 mb-2" %>
-    <div class="flex gap-4">
-      <% (1..5).each do |n| %>
-        <label class="flex flex-col items-center gap-1 cursor-pointer group">
-          <%= f.radio_button :rating, n, class: "sr-only peer" %>
-          <div class="w-10 h-10 flex items-center justify-center rounded-full border border-herb-green-200
-                      peer-checked:bg-herb-green-600 peer-checked:text-white peer-checked:border-herb-green-600
-                      group-hover:border-herb-green-400 transition-all">
-            <%= n %>
-          </div>
-        </label>
-      <% end %>
-    </div>
-  </div>
-
-  <%# 風味記録 %>
-  <div>
-    <p class="block text-sm font-medium text-herb-green-700 mb-2 text-center">風味記録（任意）</p>
-    <div class="grid grid-cols-2 gap-x-6 gap-y-4">
-      <% @flavor_tags.each do |tag| %>
-        <% column_name = TeaReview::FLAVOR_MAPPING[tag.name] %>
-        <% if column_name %>
-          <div data-controller="toggle-radio">
-            <%= f.label column_name, tag.name, class: "block text-xs font-medium text-herb-green-600 mb-2" %>
-            <div class="flex gap-1.5">
-              <% (1..5).each do |n| %>
-                <label class="flex flex-col items-center gap-1 cursor-pointer group">
-                  <%= f.radio_button column_name, n,
-                        class: "sr-only peer",
-                        data: { "toggle-radio-target": "input", action: "click->toggle-radio#toggle", "was-checked": "false" } %>
-                  <div class="w-5 h-5 flex items-center justify-center rounded-full border border-herb-green-200
-                              peer-checked:bg-herb-green-600 peer-checked:text-white peer-checked:border-herb-green-600
-                              group-hover:border-herb-green-400 transition-all text-sm">
-                    <%= n %>
-                  </div>
-                </label>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
+  <%# 評価 %>
+  <%= render 'shared/rating_form', f: f, flavor_tags: @flavor_tags, flavor_mapping: TeaReview::FLAVOR_MAPPING %>
 
   <%# 自由な感想 %>
   <div>


### PR DESCRIPTION
## 概要

スマホ表示で入力要素がカード枠外へはみ出す問題を修正し、あわせて評価フォームの
UI を共通パーシャル化・レスポンシブ化・星ボタン化しました。

## 背景

スマホ（〜375px）でページを開くと、以下がカードの外へ飛び出していました。
- ブレンド作成/編集の「作成日」入力欄（iOS の `input[type="date"]` が縮まない）
- 検索窓の評価レンジ星（Min.〜Max）

また、総合評価・風味評価の丸数字は図形を大きくすると枠外へはみ出す状態で、
評価フォームの同一マークアップが drinking_logs / tea_reviews に重複していました。

## 変更内容

- **はみ出し対策（レスポンシブ）**
  - `.form-input` に `min-w-0 max-w-full` を追加
  - `input[type="date"|"time"|"datetime-local"]` に `appearance:none / min-width:0 / max-width:100%` を付与
  - 検索窓の評価レンジ星：`flex-wrap` ＋ `min-w-0` で狭幅時に折返し、Min/Max を左右対称に
- **評価フォームの共通化・改善**
  - drinking_logs/edit・tea_reviews/_form のインライン評価 UI を `shared/_rating_form` に集約（重複削除）
  - 総合評価：丸数字 → 検索欄と同じ星ボタン（`peer-checked` ハイライト）に変更
  - 風味記録：丸サイズをレスポンシブ化（小 `w-5` → 大 `sm:w-8`）

## 確認方法

1. `docker compose exec web bin/rails tailwindcss:build` で CSS 再ビルド
2. モバイル幅（320/375px）で以下が枠内に収まることを確認
   - ブレンド作成/編集の「作成日」欄
   - recipes / tea_reviews / bookmarks の検索窓の評価レンジ星
   - drinking_log 記録・tea_review の総合評価／風味評価
3. 総合評価が星ボタンで選択でき、保存できることを確認

## 影響範囲

- 評価入力フォーム（drinking_logs 編集 / tea_reviews 新規・編集）
- 全 `.form-input` を使う入力欄（date 以外も `min-w-0` が適用）
- 検索窓の評価レンジ（recipes / tea_reviews / bookmarks）

## スクリーンショット

**評価入力・検索窓（スマホ）
| 改善前 | 改善後 |
| --- | --- |
| [![Image from Gyazo](https://i.gyazo.com/66a3204daa8bbb2011062669cbc357d0.png)](https://gyazo.com/66a3204daa8bbb2011062669cbc357d0) |  |
| [![Image from Gyazo](https://i.gyazo.com/6a0de50ae14f01f816295061a1757a14.png)](https://gyazo.com/6a0de50ae14f01f816295061a1757a14) | [![Image from Gyazo](https://i.gyazo.com/1ab19bfbbd380d6038a4030797ae04dd.png)](https://gyazo.com/1ab19bfbbd380d6038a4030797ae04dd) |

## 今後の改善事項
- 検索欄の評価ボタンについて、文字と記号の位置関係のズレの修正が必要