### PR TITLE
feat: ハーブ図鑑の画像アップロード・表示機能をCloudinaryで有効化

### DIFF
--- a/app/controllers/herbs_controller.rb
+++ b/app/controllers/herbs_controller.rb
@@ -19,6 +19,7 @@ class HerbsController < ApplicationController
     @q = Herb.ransack(params[:q])
     @herbs = apply_herb_self_filters(Herb.where(id: @q.result.select(:id)))
                  .includes(:flavor_tags, :functional_tags, :caution_tags)
+                 .with_attached_image
                  .order(:name)
                  .page(params[:page]).per(15)
   end

--- a/app/views/herbs/edit.html.erb
+++ b/app/views/herbs/edit.html.erb
@@ -104,18 +104,18 @@
               class: "form-textarea" %>
       </div>
 
-      <%# 画像（Cloudinary連携時に有効化） %>
+      <%# 画像 %>
       <%# herb_params に :image は許可済み。form_with は file_field 追加時に自動で multipart になる %>
-      <%# <div> %>
-      <%#   <p class="form-label">ハーブ画像</p> %>
-      <%#   現在の画像を表示（既存画像がある場合） %>
-      <%#   <% if @herb.image.present? %>
-      <%#     <%= image_tag @herb.image, class: "w-24 h-24 object-cover rounded-xl mb-2" %>
-      <%#   <% end %>
-      <%#   <%= form.file_field :image, accept: Herb::ACCEPTED_CONTENT_TYPES.join(","), %>
-      <%#         class: "w-full text-sm text-gray-400" %>
-      <%#   <p class="text-xs text-herb-green-700/60 mt-1">JPEG・PNG・GIF・WebP形式、5MB以下</p> %>
-      <%# </div> %>
+      <div>
+        <p class="form-label">ハーブ画像</p>
+        <%# 現在の画像を表示（既存画像がある場合） %>
+        <% if @herb.image.attached? %>
+          <%= image_tag @herb.image, class: "w-24 h-24 object-cover rounded-xl mb-2" %>
+        <% end %>
+        <%= form.file_field :image, accept: Herb::ACCEPTED_CONTENT_TYPES.join(","),
+              class: "w-full text-sm text-gray-400" %>
+        <p class="text-xs text-herb-green-700/60 mt-1">JPEG・PNG・GIF・WebP形式、5MB以下</p>
+      </div>
 
       <%# 保存ボタン %>
       <div class="pt-2 space-y-3 flex flex-col items-center">

--- a/app/views/herbs/index.html.erb
+++ b/app/views/herbs/index.html.erb
@@ -31,15 +31,15 @@
           <%= link_to herb_path(herb), class: "herb-card hover:opacity-80 transition" do %>
 
             <%# 画像（小さく・左寄り） %>
-            <%# <div class="w-12 h-12 rounded-lg overflow-hidden bg-herb-green-50 flex-shrink-0"> %>
-              <%# <% if herb.image.attached? %>
-                <%# <%= image_tag herb.image, class: "w-full h-full object-cover" %>
-              <%# <% else %>
-                <%# <div class="w-full h-full flex items-center justify-center text-herb-green-700/30 text-xs"> %>
-                  <%# NO IMG %>
-                <%# </div> %>
-              <%# <% end %>
-            <%# </div> %>
+            <div class="w-12 h-12 rounded-lg overflow-hidden bg-herb-green-50 flex-shrink-0">
+              <% if herb.image.attached? %>
+                <%= image_tag herb.image, class: "w-full h-full object-cover" %>
+              <% else %>
+                <div class="w-full h-full flex items-center justify-center text-herb-green-700/30 text-xs">
+                  NO IMG
+                </div>
+              <% end %>
+            </div>
 
             <%# テキスト情報（右側） %>
             <div class="flex-1 min-w-0">

--- a/app/views/herbs/new.html.erb
+++ b/app/views/herbs/new.html.erb
@@ -102,12 +102,13 @@
               class: "form-textarea" %>
       </div>
 
-      <%# 画像（未使用） %>
-      <%# <div> %>
-      <%#   <%= form.label :image, "ハーブ画像", class: "inline-block border rounded-full px-6 py-2" %>
-      <%#   <%= form.file_field :image, accept: Herb::ACCEPTED_CONTENT_TYPES.join(",") %>
-      <%#   <p class="text-xs text-herb-green-700/60 mt-1">JPEG・PNG・GIF・WebP形式、5MB以下</p> %>
-      <%# </div> %>
+      <%# 画像 %>
+      <div>
+        <%= form.label :image, "ハーブ画像", class: "form-label" %>
+        <%= form.file_field :image, accept: Herb::ACCEPTED_CONTENT_TYPES.join(","),
+              class: "w-full text-sm text-gray-400" %>
+        <p class="text-xs text-herb-green-700/60 mt-1">JPEG・PNG・GIF・WebP形式、5MB以下</p>
+      </div>
 
       <%# 保存ボタン %>
       <div class="pt-2 space-y-3 flex flex-col items-center">

--- a/app/views/herbs/show.html.erb
+++ b/app/views/herbs/show.html.erb
@@ -8,15 +8,15 @@
 
   <div class="flex gap-4 mb-6 justify-center">
     <%# 画像 %>
-    <%# <div class="w-full rounded-2xl overflow-hidden aspect-video"> %>
-      <%# <% if @herb.image.attached? %>
-        <%# <%= image_tag @herb.image, class: "w-full h-full object-cover" %>
-      <%# <% else %>
-        <%# <div class="w-full h-full flex items-center justify-center text-herb-green-700/30"> %>
-          <%# 画像なし %>
-        <%# </div> %>
-      <%# <% end %>
-    <%# </div> %>
+    <div class="w-full rounded-2xl overflow-hidden aspect-video">
+      <% if @herb.image.attached? %>
+        <%= image_tag @herb.image, class: "w-full h-full object-cover" %>
+      <% else %>
+        <div class="w-full h-full flex items-center justify-center text-herb-green-700/30 bg-herb-green-50">
+          画像なし
+        </div>
+      <% end %>
+    </div>
 
     <div class="flex flex-col gap-3 w-full">
       <%# 風味タグ %>


### PR DESCRIPTION
## 概要

ハーブ図鑑（Herb）に Cloudinary を利用した画像のアップロード・表示機能を実装しました。

## 背景

- 以前は画像保存先が Active Storage の **ローカル（Disk）ストレージ**だったため、Render が再起動/再デプロイで揮発性ファイルシステムを初期化すると画像が消える不具合があった。
- 対策として保存先を **Cloudinary**（外部ストレージ）へ切り替え済み。当時、画像入力欄は一旦コメントアウトして無効化していたため、今回あらためて実装し直して有効化した。

## 変更内容

| 画面 / 箇所 | 変更内容 |
| --- | --- |
| `herbs/new` | 画像選択欄（`file_field :image`）を追加。対応形式・5MB以下の注記付き |
| `herbs/show` | 画像表示を追加。未添付時は「画像なし」プレースホルダを表示 |
| `herbs/index` | 一覧カードにサムネイル（48px）を表示。未添付時は「NO IMG」 |
| `herbs/edit` | 既存画像プレビュー付きの差し替え欄を追加（判定は `attached?` に統一） |
| `HerbsController#index` | `.with_attached_image` を追加し画像表示時の N+1 を防止 |

- 設定系（`storage.yml` / `environments/*.rb` / initializer / モデル / strong params）は既に Cloudinary 向けに整備済みのため変更なし。
- `form_with` は `file_field` 追加時に自動で multipart 化されるため追加対応なし。

## 確認方法

1. Cloudinary の APIキーが有効な状態で、ハーブ新規作成フォームから画像を添付して保存
2. 詳細(show)・一覧(index) で画像が表示されること
3. 編集(edit) で別画像に差し替え → 反映されること
4. 5MB超 / 非対応形式でバリデーションエラーが出ること
5. Cloudinary の Media Library に画像が保存されていること（= ローカル保存ではない）

> 補足: 現在ローカルの Cloudinary APIキーが `disabled` 状態のため、キー有効化後に上記の保存・表示確認が可能。

## 影響範囲

- ハーブの新規作成 / 編集 / 詳細 / 一覧の各画面
- 画像保存先（Cloudinary）。本番(Render)では環境変数 `CLOUDINARY_*` の設定が前提
- 既存の保存ロジック・スキーマへの破壊的変更なし

## スクリーンショット

** ハーブ詳細・一覧・新規作成
| 改善前 | 改善後 |
| --- | --- |
|  |  |

## 関連 issue