### PR TITLE
feat: フラッシュメッセージを5秒後に自動消去する

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -263,5 +263,27 @@
       opacity: 1;
     }
   }
+  /* フラッシュメッセージ: 5秒後にフェードアウトして消去 */
+  @keyframes flash-fade-out {
+    0%, 90% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      visibility: hidden;
+    }
+  }
+
+  .flash-message {
+    animation: flash-fade-out 5s ease-in forwards;
+  }
+
+  /* アクセシビリティ: アニメーション抑制設定時は即座に消す */
+  @media (prefers-reduced-motion: reduce) {
+    .flash-message {
+      animation: none;
+      /* 表示自体は維持（手動でページ遷移時に消える） */
+    }
+  }
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,12 @@
     <%= render 'shared/header' %>
     <div class="fixed top-4 right-4 z-50 space-y-2">
       <% if notice.present? %>
-        <div class="bg-herb-green-100 border border-herb-green-600 text-herb-green-700 px-6 py-3 rounded-xl shadow-lg">
+        <div class="flash-message bg-herb-green-100 border border-herb-green-600 text-herb-green-700 px-6 py-3 rounded-xl shadow-lg">
           <%= notice %>
         </div>
       <% end %>
       <% if alert.present? %>
-        <div class="bg-red-100 border border-red-600 text-red-700 px-6 py-3 rounded-xl shadow-lg">
+        <div class="flash-message bg-red-100 border border-red-600 text-red-700 px-6 py-3 rounded-xl shadow-lg">
           <%= alert %>
         </div>
       <% end %>


### PR DESCRIPTION
## 概要

画面右上のフラッシュメッセージ（`ログインしました。` 等）を、5秒後に自動でフェードアウトして消えるようにしました。

## 背景

これまでフラッシュメッセージはページ遷移するまで表示され続け、視界の妨げになっていました。一定時間後に自動消去することで UX を改善します。

## 変更内容

- **CSS アニメーションの追加**（`application.tailwind.css`）
  - `@keyframes flash-fade-out` を定義
  - `.flash-message` クラスに `animation: flash-fade-out 5s ease-in forwards` を適用
  - `prefers-reduced-motion` 設定時はアニメーションを無効化（アクセシビリティ配慮）
- **レイアウトへのクラス付与**（`application.html.erb`）
  - `notice` / `alert` の各通知 `div` に `flash-message` クラスを追加

## 確認方法

1. `docker compose exec web bin/rails tailwindcss:build` で CSS を再ビルド
2. ログイン／ログアウトを実行
3. メッセージが約4.5秒表示された後フェードアウトし、合計5秒で消えることを確認
4. 消去後、右上付近のクリックが背後要素に通る（操作を妨げない）ことを確認

## 影響範囲

- フラッシュメッセージ（`notice` / `alert`）の表示挙動のみ
- JS・Stimulus・Rails コントローラ・モデルへの影響なし
- メッセージは5秒間 DOM に残るため、既存の system spec のアサーションへの影響なし

## 関連 issue

Closes #164 