### PR TITLE
Fix/private recipe access control

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  rescue_from ActiveRecord::RecordNotFound do
+    respond_to do |format|
+      format.html { render file: Rails.public_path.join("404.html"), status: :not_found, layout: false }
+      format.any  { head :not_found }
+    end
+  end
+
   helper_method :search_active?
 
   # 検索条件（ransack の q[] もしくは独立パラメーター）が1つでも指定されているか

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -32,9 +32,14 @@ class RecipesController < ApplicationController
   end
 
   def show
-    @recipe = Recipe.includes(:user, :drinking_log,
-      recipe_herbs: { herb: [:flavor_tags, :functional_tags, :caution_tags] }
-    ).find(params[:id])
+    scope = Recipe.includes(:user, :drinking_log,
+      recipe_herbs: { herb: [:flavor_tags, :functional_tags, :caution_tags] })
+    @recipe =
+      if user_signed_in?
+        scope.visible_to(current_user).find(params[:id])   # 公開 or 自分のもの
+      else
+        scope.public_recipes.find(params[:id])             # 未ログインは公開のみ
+      end
   end
 
   def edit

--- a/app/controllers/tea_reviews_controller.rb
+++ b/app/controllers/tea_reviews_controller.rb
@@ -1,10 +1,11 @@
 class TeaReviewsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_tea_review, only: [:show, :edit, :update, :destroy]
+  before_action :set_tea_review, only: [:show] # 閲覧は全件
+  before_action :set_own_tea_review, only: [:edit, :update, :destroy] # 編集系は所有者限定
 
   def index
-    @q = current_user.tea_reviews.ransack(params[:q])
-    base = apply_herb_based_filters(current_user.tea_reviews.where(id: @q.result.select(:id)), model: TeaReview)
+    @q = TeaReview.ransack(params[:q])
+    base = apply_herb_based_filters(TeaReview.where(id: @q.result.select(:id)), model: TeaReview)
     @tea_reviews = base
       .includes(:herbs, :user).with_attached_image.order(created_at: :desc)
       .page(params[:page]).per(10)
@@ -52,6 +53,10 @@ class TeaReviewsController < ApplicationController
   private
 
   def set_tea_review
+    @tea_review = TeaReview.find(params[:id])
+  end
+
+  def set_own_tea_review
     @tea_review = current_user.tea_reviews.find(params[:id])
   end
 


### PR DESCRIPTION
## 概要

非公開レシピが URL 直叩きで第三者・未ログインでも閲覧できる状態を是正し、あわせて tea_review を全ユーザー公開に変更しました。

## 背景

- 非公開レシピ（`is_public: false`）の秘匿性を設計として担保する必要があった。
- `RecipesController#show` が `Recipe.find` で ID を素通していた。
- tea_review は仕様上「全ユーザーに公開するコンテンツ」とするため、逆に所有者限定を開放した（ログインは必須のまま）。

## 変更内容

| 対象 | あるべき状態 | 対応 |
| --- | --- | --- |
| Recipe | 公開は全員 / 非公開は所有者のみ | 閲覧を締める |
| TeaReview | 全ユーザーに公開（ログイン必須） | 閲覧を開放 |

- **RecipesController#show にガード追加**
  - ログイン時は `visible_to(current_user)`、未ログイン時は `public_recipes` に限定
  - 権限外 ID は `RecordNotFound` → 404（存在秘匿のため 403 ではなく 404）
- **ApplicationController に 404 ハンドラ追加**
  - `rescue_from ActiveRecord::RecordNotFound` で 404 応答を統一
- **TeaReviewsController の公開化**
  - `index` を `current_user.tea_reviews` → `TeaReview` に変更（全ユーザーのレビューを表示）
  - `set_tea_review`（全件）と `set_own_tea_review`（所有者限定）を分離。`show` は全件、`edit/update/destroy` は所有者限定
  - `authenticate_user!` は全アクション維持

## 確認方法

- 未ログインで非公開レシピ `/recipes/:id` を開く → 404
- 他ユーザーで他人の非公開レシピを開く → 404
- 所有者が自分の非公開レシピを開く → 200
- 公開レシピはログイン有無に関わらず閲覧可
- ログインユーザーが他人の tea_review を `index` / `show` で閲覧可、他人の `edit` は 404

## 影響範囲

- 非公開レシピを第三者に共有していた既存 URL は 404 になる（仕様意図通り）
- 既存の `find` 由来の例外が開発環境でも一律 404 応答になる
- tea_review 一覧が全ユーザーのレビューを表示するようになる
- ⚠ tea_review の show ビューに所有者限定の編集/削除ボタンガードがあるか未確認（未ガードなら別途対応）
- Minitest によるテストは本 PR では未追加（別対応）
- ID 連番の列挙耐性（UUID/slug 化）は本 PR のスコープ外

## 関連 issue

Closes #172 