### PR TITLE
Gemini API キー管理・gem 設定

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ MAILER_SENDER=
 # 本番（Render）では Environment Variables に設定すること
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# Gemini API（AI レシピ提案 / Google AI Studio で取得）
+# https://aistudio.google.com/app/apikey
+# 本番（Render）では Environment Variables に設定すること
+GEMINI_API_KEY=
+# 使用モデル（未設定時は gemini-2.0-flash が既定値として使われる）
+GEMINI_MODEL=gemini-2.0-flash

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,10 @@ gem "image_processing", "~> 1.2"
 # Active Storage バリデーション
 gem "active_storage_validations"
 
+# HTTP クライアント（Gemini API 連携で使用）
+# cloudinary 経由の間接依存だったものを明示的な直接依存に切り出す
+gem "faraday", "~> 2.0"
+
 # 起動時間の短縮キャッシュ
 gem "bootsnap", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,6 +452,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   dotenv-rails
+  faraday (~> 2.0)
   good_job
   image_processing (~> 1.2)
   jsbundling-rails


### PR DESCRIPTION
## 概要

AI レシピ提案機能（Gemini API 連携）の第1段階として、HTTP クライアントと API キーの環境変数を整備しました。

## 背景

Issue 39「Gemini API 連携によるレシピ提案 Service」の前提整備です。設計方針により専用 gem は導入せず、Gemini 呼び出しは Faraday を直接利用します。Faraday は従来 cloudinary 経由の間接依存だったため、cloudinary の更新・削除で消える不安定さを避けるべく、明示的な直接依存へ切り出しました。

## 変更内容

| ファイル | 変更 | 内容 |
| --- | --- | --- |
| `Gemfile` | 追加 | `gem "faraday", "~> 2.0"` を直接依存として追加 |
| `Gemfile.lock` | 追加 | `DEPENDENCIES` に faraday を追記（既存バージョン 2.14.1 のまま・他 gem のバージョン変動なし） |
| `.env.example` | 追加 | `GEMINI_API_KEY` / `GEMINI_MODEL` のテンプレート行と取得先・Render 注記を追加 |

- **API キーの管理方針**
  - ローカル: `.env`（Git 管理外）に設定
  - 本番: Render の Environment Variables に `GEMINI_API_KEY` / `GEMINI_MODEL` を登録
  - `GEMINI_MODEL` 未設定時はコード側で `gemini-2.0-flash` を既定値とする想定

## 確認方法

```bash
docker compose exec web bundle install
docker compose exec web bin/rails runner 'puts Faraday::VERSION; puts ENV["GEMINI_MODEL"].inspect'
# => 2.14.1
# => "gemini-2.0-flash"
```

- `faraday` が読み込めること
- `.env` の `GEMINI_MODEL` が読めること（`GEMINI_API_KEY` は各自設定）

## 影響範囲

- 既存機能への影響なし（gem 追加と環境変数テンプレートのみ、アプリのロジック変更なし）
- faraday のバージョンは据え置きのため、cloudinary 等の既存 gem 動作に影響なし
- `Gemini::Client` 本体・提案ロジックは次 issue（39-2 以降）で実装

## スクリーンショット

なし（設定変更のみ・UI 変更なし）

## 関連 issue

Closes #97 