### PR TITLE
Gemini APIを呼び出すClient Service Objectを実装

### DIFF
--- a/app/services/gemini/client.rb
+++ b/app/services/gemini/client.rb
@@ -1,0 +1,74 @@
+# Gemini generateContent を叩く薄いラッパー。
+# JSON Schema(Structured Output) を渡し、レスポンス本文(JSON文字列)をパースして返す。
+#
+# 設計方針（.agent/development_plan/20260723_gemini_suggestion_verified_flow_plan.md §4 Fix-1/2）:
+# - 専用 gem は導入せず Faraday を直接利用する。
+# - 設定値はクラス内定数に集約する（initializer は作らない = Zeitwerk 名前空間の二重定義を回避）。
+# - API キーは URL クエリではなくヘッダ(x-goog-api-key)で送る（ログ漏洩対策）。
+module Gemini
+  class Client
+    class Error < StandardError; end
+
+    ENDPOINT     = "https://generativelanguage.googleapis.com/v1beta".freeze
+    TIMEOUT      = 20
+    OPEN_TIMEOUT = 5
+
+    def self.configured?
+      ENV["GEMINI_API_KEY"].present?
+    end
+
+    def initialize(model: ENV.fetch("GEMINI_MODEL", "gemini-2.0-flash"))
+      @model = model
+    end
+
+    # prompt: String / schema: Hash(responseSchema)
+    # 返り値: パース済み Hash（responseSchema に沿った構造）
+    def generate_json(prompt:, schema:, temperature: 0.7)
+      raise Error, "GEMINI_API_KEY 未設定" unless self.class.configured?
+
+      response = connection.post("models/#{@model}:generateContent") do |req|
+        # Fix-2: API キーはクエリではなくヘッダで送る
+        req.headers["x-goog-api-key"] = ENV["GEMINI_API_KEY"]
+        req.body = request_body(prompt, schema, temperature)
+      end
+      raise Error, "Gemini API エラー: #{response.status}" unless response.success?
+
+      extract_json(response.body)
+    rescue Faraday::TimeoutError
+      raise Error, "Gemini API タイムアウト"
+    rescue Faraday::Error => e
+      raise Error, "Gemini 接続エラー: #{e.message}"
+    end
+
+    private
+
+    def connection
+      @connection ||= Faraday.new(url: ENDPOINT) do |f|
+        f.request :json
+        f.response :json
+        f.options.timeout      = TIMEOUT
+        f.options.open_timeout = OPEN_TIMEOUT
+      end
+    end
+
+    def request_body(prompt, schema, temperature)
+      {
+        contents: [ { parts: [ { text: prompt } ] } ],
+        generationConfig: {
+          temperature: temperature,
+          responseMimeType: "application/json",
+          responseSchema: schema
+        }
+      }
+    end
+
+    def extract_json(body)
+      text = body.dig("candidates", 0, "content", "parts", 0, "text")
+      raise Error, "空レスポンス" if text.blank?
+
+      JSON.parse(text)
+    rescue JSON::ParserError
+      raise Error, "JSON パース失敗"
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Gemini API（`generateContent`）を呼び出す Service Object `Gemini::Client` を実装しました。Structured Output でレスポンスを JSON 固定にし、パース済み Hash を返します。

## 背景

Issue 39「Gemini API 連携によるレシピ提案」の第2段階です。専用 gem は導入せず、39-1 で直接依存化した Faraday を用いて薄いラッパーを自作します。設計レビュー（`20260723_..._verified_flow_plan.md` §4）で確定した修正2点を反映しています。

## 変更内容

| ファイル | 種別 | 内容 |
| --- | --- | --- |
| `app/services/gemini/client.rb` | 新規 | Gemini `generateContent` 呼び出しラッパー |

- **`Gemini::Client`**
  - `generate_json(prompt:, schema:, temperature:)` で responseSchema を渡し、パース済み Hash を返す
  - **Fix-1**: 設定値（ENDPOINT/TIMEOUT/モデル）をクラス内に集約し `config/initializers/gemini.rb` は作らない
    - `app/services/gemini/` を Zeitwerk が暗黙名前空間として扱うため、initializer での `module Gemini` 手動定義との衝突（eager_load 起動失敗）を回避
  - **Fix-2**: API キーは URL クエリではなくヘッダ `x-goog-api-key` で送信（ログ漏洩対策）
  - タイムアウト20秒 / 接続エラー / 空レスポンス / JSON パース失敗を `Gemini::Client::Error` に集約

## 確認方法

```bash
# キー未設定時（例外で落ちないこと）
docker compose exec web bin/rails runner 'Gemini::Client.new.generate_json(prompt: "x", schema: {type: "object"}) rescue (puts $!.class)'
# => Gemini::Client::Error

# 実API疎通（.env に GEMINI_API_KEY 設定後）
docker compose exec web bin/rails runner '
schema = { type: "object", properties: { fruits: { type: "array", items: { type: "string" } } }, required: ["fruits"] }
pp Gemini::Client.new.generate_json(prompt: "果物を3つ挙げて", schema: schema)'
# => {"fruits"=>[...]} の Hash が返れば成功
```

- rubocop-rails-omakase: no offenses
- ネストした提案スキーマ（`proposals[].herbs[].name/parts`）でも Hash が返ることをローカルで確認済み

## 影響範囲

- 独立した Service Object の追加のみ。呼び出し元（コントローラ/UI）はまだ無いため、**既存機能・本番挙動への影響なし**
- 提案ロジック（Finder / PromptBuilder / Generator）と UI は後続 issue で実装

## モデル設定に関する注意

- 無料枠のクォータはモデルごとに異なり、検証の結果 **`gemini-flash-latest`** が無料枠で利用可能でした（`gemini-2.0-flash` は当該キーで `limit: 0` により 429）。
- `.env` および本番（Render）の `GEMINI_MODEL` に `gemini-flash-latest` を設定してください（Client はコード変更不要で `ENV["GEMINI_MODEL"]` を参照）。

## スクリーンショット

なし（バックエンド Service のみ・UI 変更なし）
