### PR TITLE
#179 Finder検証用のレシピseedを追加

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,3 +76,8 @@ end
 # ハーブマスタ
 # -------------------------
 load Rails.root.join("db/seeds/herbs.rb")
+
+# -------------------------
+# 開発・検証用のレシピ（本番では投入しない）
+# -------------------------
+load Rails.root.join("db/seeds/dev_recipes.rb") if Rails.env.development?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,3 +71,8 @@ caution_categories = {
 caution_categories.each_value do |names|
   names.each { |name| CautionTag.find_or_create_by!(name: name) }
 end
+
+# -------------------------
+# ハーブマスタ
+# -------------------------
+load Rails.root.join("db/seeds/herbs.rb")

--- a/db/seeds/dev_recipes.rb
+++ b/db/seeds/dev_recipes.rb
@@ -1,0 +1,119 @@
+# 開発・検証用のレシピデータ。
+#
+# 目的: Gemini レシピ提案機能の Finder（効能 AND × 風味 AND × 禁忌除外）と
+#       公開/非公開スコープを、実データで検証できるようにする。
+#
+# 検証の観点ごとに、意図的に次のパターンを含めている。
+#   - 「睡眠サポート × 甘味」でヒットし、禁忌を持たない公開レシピ（ヒットすべき）
+#   - 同条件を満たすが「妊娠中注意」ハーブを含む公開レシピ（除外されるべき）
+#   - 同条件を満たすが非公開のレシピ（public_recipes で除外されるべき）
+#
+# 前提: db/seeds/herbs.rb のハーブマスタとユーザーが投入済みであること。
+DEV_RECIPES = [
+  # ── 公開・睡眠系 ─────────────────────────────
+  {
+    title: "おやすみ前のまろやかブレンド",
+    memo: "寝る前に飲むと落ち着く。甘さ控えめでまろやか。",
+    is_public: true,
+    amount: 300,
+    herbs: [ [ "リンデン", 3, :g ], [ "レモンバーム", 2, :g ], [ "ルイボス", 2, :g ] ]
+  },
+  {
+    title: "甘い夢のナイトティー",
+    memo: "ステビアで甘みを足して飲みやすく。",
+    is_public: true,
+    amount: 250,
+    herbs: [ [ "リンデン", 3, :g ], [ "ローズ", 1, :g ], [ "ステビア", 0.5, :g ] ]
+  },
+  {
+    title: "カモミールの安眠ブレンド",
+    memo: "定番の組み合わせ。妊娠中は避ける。",
+    is_public: true,
+    amount: 300,
+    herbs: [ [ "カモミールジャーマン", 3, :g ], [ "リンデン", 2, :g ] ]
+  },
+  {
+    title: "深い眠りのハーブ",
+    memo: "バレリアンは香りが強いので少量で。",
+    is_public: true,
+    amount: 200,
+    herbs: [ [ "バレリアン", 1, :teaspoon ], [ "パッションフラワー", 2, :teaspoon ] ]
+  },
+  # ── 公開・その他の系統 ───────────────────────
+  {
+    title: "ぽかぽか温活ジンジャー",
+    memo: "冷える日の朝に。ジンジャーは少なめでも十分効く。",
+    is_public: true,
+    amount: 300,
+    herbs: [ [ "ジンジャー", 1, :g ], [ "ルイボス", 3, :g ], [ "オレンジピール", 2, :g ] ]
+  },
+  {
+    title: "うるおい美肌ブレンド",
+    memo: "酸味が強いので蜂蜜を足しても良い。",
+    is_public: true,
+    amount: 300,
+    herbs: [ [ "ローズヒップ", 3, :g ], [ "ハイビスカス", 2, :g ], [ "ローズ", 1, :g ] ]
+  },
+  {
+    title: "すっきりリフレッシュミント",
+    memo: "食後や気分を切り替えたいときに。",
+    is_public: true,
+    amount: 250,
+    herbs: [ [ "ペパーミント", 2, :g ], [ "オレンジピール", 2, :g ] ]
+  },
+  # ── 非公開（public_recipes スコープの検証用）─────
+  {
+    title: "試作：おやすみリンデン",
+    memo: "非公開。睡眠×甘味の条件を満たすが公開していない。",
+    is_public: false,
+    amount: 250,
+    herbs: [ [ "リンデン", 3, :g ], [ "ステビア", 0.5, :g ] ]
+  },
+  {
+    title: "試作：喉ケアブレンド",
+    memo: "非公開。タイムの苦味が強いので調整中。",
+    is_public: false,
+    amount: 200,
+    herbs: [ [ "タイム", 1, :g ], [ "リコリス", 0.5, :g ], [ "エルダーフラワー", 2, :g ] ]
+  },
+  {
+    title: "試作：デトックスブレンド",
+    memo: "非公開。苦味が強く飲みにくいので配合を検討中。",
+    is_public: false,
+    amount: 300,
+    herbs: [ [ "ダンデライオン", 2, :g ], [ "ネトル", 2, :g ] ]
+  }
+].freeze
+
+users = User.order(:id).to_a
+if users.empty?
+  puts "⚠ ユーザーが存在しないため、開発用レシピの投入をスキップしました"
+else
+  DEV_RECIPES.each_with_index do |data, index|
+    owner = users[index % users.size]
+
+    recipe = Recipe.find_or_initialize_by(user: owner, title: data[:title])
+    recipe.assign_attributes(
+      memo: data[:memo],
+      is_public: data[:is_public],
+      amount: data[:amount],
+      brewed_at: Date.current - index.days
+    )
+    recipe.save!
+
+    # 配合は seed を正として毎回作り直す（実行のたびに重複しないようにする）
+    recipe.recipe_herbs.destroy_all
+    data[:herbs].each do |herb_name, quantity, unit|
+      herb = Herb.find_by(name: herb_name)
+      if herb.nil?
+        puts "  ⚠ #{data[:title]}: ハーブ「#{herb_name}」が見つかりません"
+        next
+      end
+
+      recipe.recipe_herbs.create!(herb: herb, quantity: quantity, unit: unit)
+    end
+  end
+
+  puts "開発用レシピ: #{DEV_RECIPES.size} 件を投入しました" \
+       "（公開 #{Recipe.public_recipes.count} 件 / 全 #{Recipe.count} 件）"
+end

--- a/db/seeds/herbs.rb
+++ b/db/seeds/herbs.rb
@@ -1,0 +1,185 @@
+# ハーブマスタ（名前 → 説明 / 風味 / 効能 / 禁忌タグ）
+#
+# 前提: 風味・効能・禁忌の各タグは db/seeds.rb で作成済みであること。
+# 方針: このファイルを「ハーブマスタの唯一の正」とする。
+#   - ハーブ本体は find_or_create_by! で冪等に作成する。
+#   - タグは代入（上書き）で同期し、手作業でついた不正確な紐付けを残さない。
+#   - 一覧に無い既存ハーブ（ユーザーが画面から登録したもの等）には触れない。
+#     Herb は dependent: :destroy で recipe_herbs を連鎖削除するため、削除は行わない。
+HERB_SEEDS = [
+  {
+    name: "カモミールジャーマン",
+    description: "りんごのような甘い香り。心と胃腸をゆるめる代表的なリラックスハーブ。",
+    flavors: %w[甘味 まろやかさ 華やかさ],
+    functions: [ "リラックス（鎮静）", "睡眠サポート", "胃腸ケア" ],
+    cautions: %w[妊娠中注意 アレルギー注意]
+  },
+  {
+    name: "カモミールローマン",
+    description: "ジャーマンより苦味が強く、香りが濃い。少量をブレンドに加えると香りが引き締まる。",
+    flavors: %w[苦味 華やかさ],
+    functions: [ "リラックス（鎮静）", "鎮痙作用" ],
+    cautions: %w[妊娠中注意 アレルギー注意]
+  },
+  {
+    name: "ラベンダー",
+    description: "清涼感のある花の香り。緊張をほぐし眠りへ導く。入れすぎると苦味が出る。",
+    flavors: %w[華やかさ 苦味],
+    functions: [ "リラックス（鎮静）", "ストレス緩和", "睡眠サポート" ],
+    cautions: %w[妊娠中注意]
+  },
+  {
+    name: "レモンバーム",
+    description: "やさしいレモンの香り。神経性の胃の不調にも用いられる。",
+    flavors: %w[清涼感 酸味 まろやかさ],
+    functions: [ "リラックス（鎮静）", "ストレス緩和", "胃腸ケア" ],
+    cautions: []
+  },
+  {
+    name: "リンデン",
+    description: "ほんのり甘くまろやか。就寝前のブレンドのベースに向く。",
+    flavors: %w[甘味 まろやかさ],
+    functions: [ "リラックス（鎮静）", "睡眠サポート", "発汗作用" ],
+    cautions: []
+  },
+  {
+    name: "パッションフラワー",
+    description: "「植物性のトランキライザー」とも呼ばれる穏やかな鎮静ハーブ。",
+    flavors: %w[まろやかさ],
+    functions: [ "睡眠サポート", "リラックス（鎮静）" ],
+    cautions: %w[妊娠中注意 鎮静作用あり]
+  },
+  {
+    name: "バレリアン",
+    description: "独特の強い香りと苦味。少量で深い休息をサポートする。",
+    flavors: %w[苦味],
+    functions: [ "睡眠サポート", "リラックス（鎮静）" ],
+    cautions: %w[薬剤服用中注意 鎮静作用あり]
+  },
+  {
+    name: "ペパーミント",
+    description: "強い清涼感。食後の重さや気分の切り替えに。",
+    flavors: %w[清涼感],
+    functions: [ "消化促進", "胃腸ケア", "気分リフレッシュ" ],
+    cautions: %w[小児使用注意]
+  },
+  {
+    name: "ローズヒップ",
+    description: "ビタミンCが豊富で酸味が強い。ハイビスカスと好相性。",
+    flavors: %w[酸味 フルーティー],
+    functions: [ "美肌ケア", "免疫サポート", "抗酸化" ],
+    cautions: []
+  },
+  {
+    name: "ハイビスカス",
+    description: "鮮やかな赤色と強い酸味。運動後の疲労回復に。",
+    flavors: %w[酸味 フルーティー],
+    functions: [ "疲労回復", "利尿作用" ],
+    cautions: %w[低血圧注意 利尿作用あり]
+  },
+  {
+    name: "ルイボス",
+    description: "ノンカフェインでクセが少なく、ブレンドのベースにしやすい。",
+    flavors: %w[まろやかさ 甘味],
+    functions: [ "抗酸化", "整腸作用", "冷え対策" ],
+    cautions: []
+  },
+  {
+    name: "ローズ",
+    description: "華やかな香りで気分を高める。女性向けブレンドの定番。",
+    flavors: %w[華やかさ 甘味],
+    functions: [ "ストレス緩和", "ホルモンバランス", "美肌ケア" ],
+    cautions: %w[ホルモン感受性注意]
+  },
+  {
+    name: "リコリス",
+    description: "砂糖の数十倍の甘さ。ごく少量で全体をまとめる甘味役。",
+    flavors: %w[甘味],
+    functions: [ "喉ケア", "抗炎症" ],
+    cautions: %w[高血圧注意 妊娠中注意]
+  },
+  {
+    name: "ジンジャー",
+    description: "体を温めるスパイス。冷え対策ブレンドの主役。",
+    flavors: %w[スパイシー],
+    functions: [ "血行促進", "冷え対策", "消化促進" ],
+    cautions: %w[妊娠中注意 抗凝固薬注意]
+  },
+  {
+    name: "ネトル",
+    description: "緑茶に似た渋みとミネラル感。春先の不調ケアに用いられる。",
+    flavors: %w[渋味],
+    functions: [ "ミネラル補給", "抗アレルギー" ],
+    cautions: %w[利尿作用あり]
+  },
+  {
+    name: "エルダーフラワー",
+    description: "マスカットのような香り。風邪のひきはじめの定番。",
+    flavors: %w[華やかさ 甘味],
+    functions: [ "免疫サポート", "発汗作用" ],
+    cautions: []
+  },
+  {
+    name: "オレンジピール",
+    description: "柑橘の甘い香りで飲みやすさを底上げする名脇役。",
+    flavors: %w[フルーティー 甘味],
+    functions: [ "気分リフレッシュ", "消化促進" ],
+    cautions: %w[光感作注意]
+  },
+  {
+    name: "ステビア",
+    description: "低カロリーの強い甘味。砂糖の代わりに極少量で使う。",
+    flavors: %w[甘味],
+    functions: [ "血糖値サポート" ],
+    cautions: []
+  },
+  {
+    name: "エキナセア",
+    description: "ネイティブアメリカン伝統の免疫ハーブ。季節の変わり目に。",
+    flavors: %w[苦味 渋味],
+    functions: [ "免疫サポート", "抗ウイルス", "抗菌" ],
+    cautions: %w[アレルギー注意 薬剤服用中注意]
+  },
+  {
+    name: "ダンデライオン",
+    description: "根を焙煎するとコーヒーに似た風味。むくみケアに。",
+    flavors: %w[苦味],
+    functions: [ "デトックス", "利尿作用", "整腸作用" ],
+    cautions: %w[利尿作用あり アレルギー注意]
+  },
+  {
+    name: "ローリエ",
+    description: "料理でおなじみの月桂樹。すっきりした香りで食後に。",
+    flavors: %w[スパイシー 苦味],
+    functions: [ "消化促進", "食欲調整" ],
+    cautions: %w[妊娠中注意]
+  },
+  {
+    name: "タイム",
+    description: "強い抗菌力で知られる。喉の不調時のブレンドに。",
+    flavors: %w[スパイシー 苦味],
+    functions: [ "抗菌", "喉ケア", "抗ウイルス" ],
+    cautions: %w[妊娠中注意]
+  }
+].freeze
+
+# タグ名から実レコードを引く。未登録の名前は警告して気づけるようにする。
+def fetch_tags(klass, names, herb_name)
+  return [] if names.blank?
+
+  found = klass.where(name: names).to_a
+  missing = names - found.map(&:name)
+  puts "  ⚠ #{herb_name}: 未登録タグ #{missing.join('、')}（#{klass.name}）" if missing.any?
+
+  found
+end
+
+HERB_SEEDS.each do |data|
+  herb = Herb.find_or_create_by!(name: data[:name])
+  herb.update!(description: data[:description])
+  herb.flavor_tags     = fetch_tags(FlavorTag,     data[:flavors],   data[:name])
+  herb.functional_tags = fetch_tags(FunctionalTag, data[:functions], data[:name])
+  herb.caution_tags    = fetch_tags(CautionTag,    data[:cautions],  data[:name])
+end
+
+puts "ハーブマスタ: #{HERB_SEEDS.size} 件を投入しました（Herb.count = #{Herb.count}）"


### PR DESCRIPTION
## 概要

Gemini レシピ提案機能の Finder（効能 AND × 風味 AND × 禁忌除外）と公開スコープを実データで検証できるよう、開発用のレシピ seed を追加しました。

> ⚠️ このPRは #178（ハーブマスタの seed ファイル化）に依存するため、ベースブランチを `feature/#177-herb-master-seed` にしています。#178 のマージ後、ベースが自動的に main へ切り替わります。

## 背景

2026-07-29 の開発環境データ刷新でレシピを全削除したため、レシピが 0 件でした。
このままでは Finder を実装しても常に 0 件を返し、絞り込みロジックの動作確認ができません。

参照: `.agent/development_plan/20260723_gemini_suggestion_verified_flow_plan.md` §5 Issue C-0

## 変更内容

- **`db/seeds/dev_recipes.rb`（新規）**
  - 公開7件・非公開3件の計10件を投入
  - 検証観点ごとに意図したパターンを配置

| レシピ | 公開 | 検証の意図 |
| --- | --- | --- |
| おやすみ前のまろやかブレンド | 公開 | 睡眠×甘味に合致し禁忌なし（**ヒットすべき**） |
| 甘い夢のナイトティー | 公開 | 同上（**ヒットすべき**） |
| カモミールの安眠ブレンド | 公開 | 条件は満たすが妊娠中注意を含む（**除外されるべき**） |
| 試作：おやすみリンデン | 非公開 | 条件を満たすが非公開（**除外されるべき**） |
| ぽかぽか温活ジンジャー 他 | 公開 | 冷え対策・美容・リフレッシュ系の別系統 |

  - 配合は実行のたびに作り直すため、複数回実行しても重複しません
- **`db/seeds.rb`（追記のみ）**
  - `if Rails.env.development?` のガード付きで読み込み。本番にダミーレシピは入りません

## 確認方法

```bash
docker compose exec web bin/rails db:seed
```

プラン §2-1 の検証パターンで、Finder のロジックを再現して確認済みです。

| 条件 | 結果 |
| --- | --- |
| 睡眠サポート × 甘味（禁忌除外なし） | おやすみ前のまろやかブレンド / カモミールの安眠ブレンド / 甘い夢のナイトティー（3件） |
| 上記 ＋ 妊娠中注意を除外 | おやすみ前のまろやかブレンド / 甘い夢のナイトティー（2件） |
| 非公開レシピの混入 | なし（試作：おやすみリンデンは結果に含まれない） |

禁忌除外により「カモミールの安眠ブレンド」が正しく落ち、非公開レシピも除外されることを確認しました。
プラン §2-3 が想定していた表示例と同じ2件が返っています。

2回続けて `db:seed` を実行し、Recipe 10件 / RecipeHerb 25件 が変化しないこと（冪等）も確認済みです。

## 影響範囲

- 開発環境限定です。本番・テスト環境には投入されません
- アプリコードの変更はありません
- 既存レシピは削除しません（同名・同ユーザーのレシピがある場合のみ配合を作り直します）

## 関連 issue

Closes #179