### PR TITLE
#181 既存公開レシピのマッチングService（Finder）を実装

### DIFF
--- a/app/services/recipe_suggestion/finder.rb
+++ b/app/services/recipe_suggestion/finder.rb
@@ -1,0 +1,58 @@
+# 聞き取りパラメータから、条件に合う「公開レシピ」を DB から探す。
+#
+# Gemini を使わないため無料・確実に動く。AI 提案（Generator）が失敗しても
+# この結果は表示され続ける、というフォールバックの役割も担う。
+#
+# 絞り込みは ApplicationController#apply_herb_based_filters と同じ考え方:
+#   - 効能・風味は「指定タグをすべて含む」AND 条件
+#   - 禁忌は「該当タグを持つハーブを含むレシピ」を除外
+# いずれもハーブ経由（recipe → herbs → tags）で判定する。
+module RecipeSuggestion
+  class Finder
+    DEFAULT_LIMIT = 5
+
+    def initialize(params)
+      @params = params || {}
+    end
+
+    def call(limit: DEFAULT_LIMIT)
+      scope = Recipe.public_recipes
+      scope = filter_by_all_tags(scope, :functional_tags, @params[:functional_names])
+      scope = filter_by_all_tags(scope, :flavor_tags, @params[:flavor_names])
+      scope = exclude_by_caution(scope, @params[:exclude_caution_tags])
+
+      scope.includes(:user, :drinking_log, recipe_herbs: :herb)
+           .recent
+           .limit(limit)
+    end
+
+    private
+
+    # 指定タグを「すべて」含むレシピに絞る。
+    # タグごとにサブクエリで id を絞るため、join による重複行は発生しない。
+    def filter_by_all_tags(scope, tag_association, names)
+      normalize(names).each do |name|
+        matched_ids = Recipe.joins(herbs: tag_association)
+                            .where(tag_association => { name: name })
+                            .select(:id)
+        scope = scope.where(id: matched_ids)
+      end
+      scope
+    end
+
+    # 指定した禁忌タグを持つハーブを含むレシピを除外する。
+    def exclude_by_caution(scope, names)
+      names = normalize(names)
+      return scope if names.empty?
+
+      excluded_ids = Recipe.joins(herbs: :caution_tags)
+                           .where(caution_tags: { name: names })
+                           .select(:id)
+      scope.where.not(id: excluded_ids)
+    end
+
+    def normalize(names)
+      Array(names).map { |name| name.to_s.strip }.reject(&:blank?)
+    end
+  end
+end

--- a/test/fixtures/caution_tags.yml
+++ b/test/fixtures/caution_tags.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
+pregnancy:
+  name: 妊娠中注意
 
-two:
-  name: MyString
+allergy:
+  name: アレルギー注意

--- a/test/fixtures/drinking_logs.yml
+++ b/test/fixtures/drinking_logs.yml
@@ -1,27 +1,29 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+#
+# Recipe has_one :drinking_log のため、1レシピにつき1件まで。
 
-one:
-  recipe: one
-  rating: 1
-  sweetness: 1
+sleep_safe_log:
+  recipe: public_sleep_safe
+  rating: 5
+  sweetness: 4
   bitterness: 1
   astringency: 1
-  freshness: 1
-  savory: 1
+  freshness: 2
   spicy: 1
-  fruity: 1
+  fruity: 2
   acidity: 1
-  impression: MyText
+  flowery: 3
+  impression: 寝る前にちょうどよい甘さだった。
 
-two:
-  recipe: two
-  rating: 1
-  sweetness: 1
+skin_care_log:
+  recipe: public_skin_care
+  rating: 4
+  sweetness: 2
   bitterness: 1
-  astringency: 1
-  freshness: 1
-  savory: 1
+  astringency: 2
+  freshness: 3
   spicy: 1
-  fruity: 1
-  acidity: 1
-  impression: MyText
+  fruity: 5
+  acidity: 5
+  flowery: 2
+  impression: 酸味が強いので蜂蜜を足したい。

--- a/test/fixtures/flavor_tags.yml
+++ b/test/fixtures/flavor_tags.yml
@@ -1,7 +1,10 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
+sweet:
+  name: 甘味
 
-two:
-  name: MyString
+mellow:
+  name: まろやかさ
+
+sour:
+  name: 酸味

--- a/test/fixtures/functional_tags.yml
+++ b/test/fixtures/functional_tags.yml
@@ -1,7 +1,10 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
+sleep_support:
+  name: 睡眠サポート
 
-two:
-  name: MyString
+relax:
+  name: リラックス（鎮静）
+
+skin_care:
+  name: 美肌ケア

--- a/test/fixtures/herb_caution_tags.yml
+++ b/test/fixtures/herb_caution_tags.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  herb: one
-  caution_tag: one
+chamomile_pregnancy:
+  herb: chamomile
+  caution_tag: pregnancy
 
-two:
-  herb: two
-  caution_tag: two
+chamomile_allergy:
+  herb: chamomile
+  caution_tag: allergy

--- a/test/fixtures/herb_flavor_tags.yml
+++ b/test/fixtures/herb_flavor_tags.yml
@@ -1,9 +1,17 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  herb: one
-  flavor_tag: one
+linden_sweet:
+  herb: linden
+  flavor_tag: sweet
 
-two:
-  herb: two
-  flavor_tag: two
+linden_mellow:
+  herb: linden
+  flavor_tag: mellow
+
+chamomile_sweet:
+  herb: chamomile
+  flavor_tag: sweet
+
+rosehip_sour:
+  herb: rosehip
+  flavor_tag: sour

--- a/test/fixtures/herb_functional_tags.yml
+++ b/test/fixtures/herb_functional_tags.yml
@@ -1,9 +1,21 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  herb: one
-  functional_tag: one
+linden_sleep:
+  herb: linden
+  functional_tag: sleep_support
 
-two:
-  herb: two
-  functional_tag: two
+linden_relax:
+  herb: linden
+  functional_tag: relax
+
+chamomile_sleep:
+  herb: chamomile
+  functional_tag: sleep_support
+
+chamomile_relax:
+  herb: chamomile
+  functional_tag: relax
+
+rosehip_skin:
+  herb: rosehip
+  functional_tag: skin_care

--- a/test/fixtures/herbs.yml
+++ b/test/fixtures/herbs.yml
@@ -1,13 +1,18 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+#
+# 提案機能の検証で使う最小構成。
+#   linden      : 睡眠サポート・リラックス / 甘味・まろやかさ / 禁忌なし
+#   chamomile   : 睡眠サポート・リラックス / 甘味          / 妊娠中注意（除外テスト用）
+#   rosehip     : 美肌ケア                / 酸味          / 禁忌なし
 
-one:
-  name: MyString
-  description: MyText
-  image: MyString
-  caution: MyText
+linden:
+  name: リンデン
+  description: ほんのり甘くまろやか。就寝前のブレンドのベースに向く。
 
-two:
-  name: MyString
-  description: MyText
-  image: MyString
-  caution: MyText
+chamomile:
+  name: カモミールジャーマン
+  description: りんごのような甘い香り。妊娠中は避ける。
+
+rosehip:
+  name: ローズヒップ
+  description: ビタミンCが豊富で酸味が強い。

--- a/test/fixtures/recipe_herbs.yml
+++ b/test/fixtures/recipe_herbs.yml
@@ -1,13 +1,31 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  recipe: one
-  herb: one
-  quantity: 1.5
-  unit: 1
+sleep_safe_linden:
+  recipe: public_sleep_safe
+  herb: linden
+  quantity: 3.0
+  unit: 2
 
-two:
-  recipe: two
-  herb: two
-  quantity: 1.5
-  unit: 1
+sleep_caution_chamomile:
+  recipe: public_sleep_caution
+  herb: chamomile
+  quantity: 3.0
+  unit: 2
+
+sleep_caution_linden:
+  recipe: public_sleep_caution
+  herb: linden
+  quantity: 2.0
+  unit: 2
+
+private_sleep_linden:
+  recipe: private_sleep_safe
+  herb: linden
+  quantity: 3.0
+  unit: 2
+
+skin_care_rosehip:
+  recipe: public_skin_care
+  herb: rosehip
+  quantity: 3.0
+  unit: 2

--- a/test/fixtures/recipes.yml
+++ b/test/fixtures/recipes.yml
@@ -1,11 +1,31 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+#
+# Finder の検証パターン（睡眠サポート × 甘味 × 妊娠中注意除外）に対応。
+#   public_sleep_safe   : 条件を満たし禁忌なし        → ヒットすべき
+#   public_sleep_caution: 条件を満たすが妊娠中注意あり → 除外されるべき
+#   private_sleep_safe  : 条件を満たすが非公開        → 除外されるべき
+#   public_skin_care    : 別系統（美肌ケア）
 
-one:
-  user: one
-  title: MyString
-  content: MyText
+public_sleep_safe:
+  user: alice
+  title: おやすみ前のまろやかブレンド
+  brewed_at: 2026-07-01
+  is_public: true
 
-two:
-  user: two
-  title: MyString
-  content: MyText
+public_sleep_caution:
+  user: alice
+  title: カモミールの安眠ブレンド
+  brewed_at: 2026-07-02
+  is_public: true
+
+private_sleep_safe:
+  user: bob
+  title: 試作おやすみリンデン
+  brewed_at: 2026-07-03
+  is_public: false
+
+public_skin_care:
+  user: bob
+  title: うるおい美肌ブレンド
+  brewed_at: 2026-07-04
+  is_public: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+alice:
+  email: alice@example.com
+  name: Alice
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password123") %>
+
+bob:
+  email: bob@example.com
+  name: Bob
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password123") %>

--- a/test/services/recipe_suggestion/finder_test.rb
+++ b/test/services/recipe_suggestion/finder_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+module RecipeSuggestion
+  class FinderTest < ActiveSupport::TestCase
+    # fixture の構成:
+    #   public_sleep_safe    公開 / リンデン（睡眠サポート・甘味・禁忌なし）
+    #   public_sleep_caution 公開 / カモミール（妊娠中注意）＋リンデン
+    #   private_sleep_safe   非公開 / リンデン
+    #   public_skin_care     公開 / ローズヒップ（美肌ケア・酸味）
+
+    test "条件未指定なら公開レシピをすべて返す" do
+      titles = Finder.new({}).call.map(&:title)
+
+      assert_includes titles, recipes(:public_sleep_safe).title
+      assert_includes titles, recipes(:public_skin_care).title
+      assert_equal 3, titles.size
+    end
+
+    test "非公開レシピを含まない" do
+      titles = Finder.new({}).call.map(&:title)
+
+      assert_not_includes titles, recipes(:private_sleep_safe).title
+    end
+
+    test "効能タグで絞り込める" do
+      titles = Finder.new(functional_names: [ "睡眠サポート" ]).call.map(&:title)
+
+      assert_includes titles, recipes(:public_sleep_safe).title
+      assert_includes titles, recipes(:public_sleep_caution).title
+      assert_not_includes titles, recipes(:public_skin_care).title
+    end
+
+    test "効能と風味を両方指定するとAND条件で絞り込む" do
+      titles = Finder.new(
+        functional_names: [ "睡眠サポート" ],
+        flavor_names: [ "酸味" ]
+      ).call.map(&:title)
+
+      # 睡眠サポートと酸味を両方満たすレシピは存在しない
+      assert_empty titles
+    end
+
+    test "複数の効能タグを指定するとすべて含むレシピだけを返す" do
+      titles = Finder.new(
+        functional_names: [ "睡眠サポート", "美肌ケア" ]
+      ).call.map(&:title)
+
+      assert_empty titles
+    end
+
+    test "禁忌タグを持つハーブを含むレシピを除外する" do
+      titles = Finder.new(
+        functional_names: [ "睡眠サポート" ],
+        flavor_names: [ "甘味" ],
+        exclude_caution_tags: [ "妊娠中注意" ]
+      ).call.map(&:title)
+
+      assert_includes titles, recipes(:public_sleep_safe).title
+      assert_not_includes titles, recipes(:public_sleep_caution).title
+    end
+
+    test "禁忌未指定なら除外しない" do
+      titles = Finder.new(
+        functional_names: [ "睡眠サポート" ],
+        flavor_names: [ "甘味" ]
+      ).call.map(&:title)
+
+      assert_includes titles, recipes(:public_sleep_caution).title
+    end
+
+    test "空文字やnilの条件は無視する" do
+      titles = Finder.new(
+        functional_names: [ "", nil, " 睡眠サポート " ],
+        flavor_names: [],
+        exclude_caution_tags: [ "" ]
+      ).call.map(&:title)
+
+      assert_includes titles, recipes(:public_sleep_safe).title
+      assert_not_includes titles, recipes(:public_skin_care).title
+    end
+
+    test "該当0件でも例外にせず空を返す" do
+      result = Finder.new(functional_names: [ "存在しないタグ" ]).call
+
+      assert_empty result
+    end
+
+    test "limitで件数を制限できる" do
+      assert_equal 1, Finder.new({}).call(limit: 1).size
+    end
+
+    test "新しい順に並ぶ" do
+      titles = Finder.new({}).call.map(&:title)
+
+      assert_equal recipes(:public_skin_care).title, titles.first
+    end
+  end
+end


### PR DESCRIPTION
## 概要

聞き取り条件に合う既存の公開レシピを DB から検索する `RecipeSuggestion::Finder` を実装しました。あわせて、実スキーマと不整合だったテスト fixture を整備しています。

## 背景

Gemini レシピ提案機能は「① 既存の公開レシピ表示」と「② AI による新規提案」の2系統で構成されます。
① は Gemini を使わないため無料で確実に動作し、AI 提案が失敗した際のフォールバックにもなります。

参照: `.agent/development_plan/20260723_gemini_suggestion_verified_flow_plan.md` §5 Issue C

## 変更内容

- **`app/services/recipe_suggestion/finder.rb`（新規）**
  - 効能・風味は「指定タグをすべて含む」AND 条件で絞り込み
  - 禁忌は「該当タグを持つハーブを含むレシピ」を除外
  - いずれもハーブ経由（recipe → herbs → tags）で判定し、`ApplicationController#apply_herb_based_filters` と同じ考え方を踏襲
  - タグごとにサブクエリで id を絞るため join による重複行が出ず、`distinct` が不要
  - `includes(:user, :drinking_log, recipe_herbs: :herb)` で N+1 を防止
- **`test/fixtures/*.yml`（整備）**
  - 自動生成のスタブが実スキーマと不整合で、テストを書ける状態になかったため差し替え
  - 存在しないカラムへの参照（`recipes.content` / `herbs.caution` / `drinking_logs.savory`）を解消
  - `herbs.name` が `MyString` で重複し uniqueness 違反になる問題を解消
  - 提案機能の検証に使うハーブ3種・タグ・レシピ4件の構成へ変更
- **`test/services/recipe_suggestion/finder_test.rb`（新規）**
  - 絞り込み・除外・スコープ・入力の正規化・limit・並び順を11ケースで検証

## 確認方法

```bash
docker compose exec web bin/rails test test/services/recipe_suggestion/finder_test.rb
# 11 runs, 31 assertions, 0 failures, 0 errors
```

fixture の構成と検証内容は次のとおりです。

| レシピ | 公開 | 含むハーブ | 期待する挙動 |
| --- | --- | --- | --- |
| おやすみ前のまろやかブレンド | 公開 | リンデン（睡眠・甘味・禁忌なし） | 条件に合致しヒットする |
| カモミールの安眠ブレンド | 公開 | カモミール（妊娠中注意）＋リンデン | 禁忌除外で落ちる |
| 試作おやすみリンデン | 非公開 | リンデン | 公開スコープで落ちる |
| うるおい美肌ブレンド | 公開 | ローズヒップ（美肌ケア・酸味） | 別系統として残る |

## 影響範囲

- 新規 Service の追加のみで、既存のコントローラ・ビューからは未使用です（UI 接続は Issue B / E で実施）
- **既存テストの状態**: main の時点で 17 件がエラー（自動生成された scaffold のテストが `herbs_new_url` など存在しないルートヘルパーを参照）でした。本 PR 後も同じ17件のままで、新たな失敗は増えていません

| | main | 本PR |
| --- | --- | --- |
| 実行数 | 17 | 28 |
| エラー | 17（既存） | 17（同一・未修正） |
| 失敗 | 0 | 0 |

> scaffold テストの修正は本 PR のスコープ外とし、別 issue とすることを提案します。

## 関連 issue

Closes #181